### PR TITLE
7. Kubernetes-related changes

### DIFF
--- a/src/afc-packages/afcworker/afc_worker.py
+++ b/src/afc-packages/afcworker/afc_worker.py
@@ -41,7 +41,7 @@ class WorkerConfig(BrokerConfigurator):
 
 conf = WorkerConfig()
 
-rcache_settings = RcacheClientSettings()
+rcache_settings = RcacheClientSettings(postgres_dsn=None)
 # In this validation rcache is True to handle 'update_on_send' case
 rcache_settings.validate_for(rmq=True, rcache=True)
 rcache = RcacheClient(rcache_settings, rmq_receiver=False) \

--- a/tools/rcache/compose_rcache.yaml
+++ b/tools/rcache/compose_rcache.yaml
@@ -13,5 +13,5 @@ services:
     image: rcache_tool:${TAG:-latest}
     environment:
       - RCACHE_POSTGRES_DSN=postgresql://postgres:postgres@bulk_postgres/rcache
-      - RCACHE_SERVICE_URL=http://rcache:${RCACHE_PORT}
+      - RCACHE_SERVICE_URL=http://rcache:${RCACHE_CLIENT_PORT}
     dns_search: [.]


### PR DESCRIPTION
- Explicitly disabled unused parameters in RcacheClientSettings() in worker to void their trickling from environment variables (and causing initialization failure)
- Renamed RCACHE_PORT to RCACHE_CLIENT_PORT in compose_rcache.yaml