### PR TITLE
25. Fixing confluent-kafka client obtaining

### DIFF
--- a/als/Dockerfile.siphon
+++ b/als/Dockerfile.siphon
@@ -16,9 +16,12 @@ WORKDIR /usr/app
 
 RUN apk add --update --no-cache python3=~3.11 py3-sqlalchemy=~1.4 py3-pip \
     py3-psycopg2 py3-pydantic=~1.10 py3-alembic py3-lz4
-
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-    py3-confluent-kafka
+    
+# Installing Confluent Kafka Python client. Eventually, hopefully, it will be
+# installed as Alpine package (thus not requiring gcc and musl-dev install)
+RUN apk add --update --no-cache python3-dev=~3.11 gcc musl-dev \
+    librdkafka-dev=~2.1.1
+RUN pip3 install confluent-kafka==2.1.1
 
 COPY requirements.txt /usr/app/
 RUN pip3 install --no-cache-dir --root-user-action=ignore -r requirements.txt

--- a/cert_db/Dockerfile
+++ b/cert_db/Dockerfile
@@ -11,9 +11,13 @@ ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python && \
 apk add --update --no-cache py3-sqlalchemy py3-cryptography py3-numpy \
 py3-requests py3-flask py3-psycopg2 py3-pydantic=~1.10 && python3 -m ensurepip && \
-apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-py3-confluent-kafka && \
 pip3 install --no-cache --upgrade pip setuptools
+
+# Installing Confluent Kafka Python client. Eventually, hopefully, it will be
+# installed as Alpine package (thus not requiring gcc and musl-dev install)
+RUN apk add --update --no-cache python3-dev=~3.11 gcc musl-dev \
+    librdkafka-dev=~2.1.1
+RUN pip3 install confluent-kafka==2.1.1
 
 COPY cert_db/requirements.txt /wd/
 RUN pip3 install -r /wd/requirements.txt && mkdir -p /etc/xdg/fbrat

--- a/msghnd/Dockerfile
+++ b/msghnd/Dockerfile
@@ -11,10 +11,15 @@ ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python && \
 apk add --update --no-cache py3-six py3-numpy py3-cryptography py3-sqlalchemy \
 py3-requests py3-flask py3-psycopg2 py3-pydantic=~1.10 && \
-apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-py3-confluent-kafka && \
 python3 -m ensurepip && \
 pip3 install --no-cache --upgrade pip setuptools
+
+# Installing Confluent Kafka Python client. Eventually, hopefully, it will be
+# installed as Alpine package (thus not requiring gcc and musl-dev install)
+RUN apk add --update --no-cache python3-dev=~3.11 gcc musl-dev \
+    librdkafka-dev=~2.1.1
+RUN pip3 install confluent-kafka==2.1.1
+
 COPY msghnd/requirements.txt /wd/
 RUN pip3 install -r /wd/requirements.txt && mkdir -p /run/gunicorn /etc/xdg/fbrat
 COPY gunicorn/wsgi.py /wd/

--- a/rat_server/Dockerfile
+++ b/rat_server/Dockerfile
@@ -11,10 +11,15 @@ ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python && \
 apk add --update --no-cache py3-six py3-numpy py3-cryptography py3-sqlalchemy \
 py3-requests py3-flask py3-psycopg2 py3-pydantic=~1.10 postfix && \
-apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-py3-confluent-kafka && \
 python3 -m ensurepip && \
 pip3 install --no-cache --upgrade pip setuptools
+
+# Installing Confluent Kafka Python client. Eventually, hopefully, it will be
+# installed as Alpine package (thus not requiring gcc and musl-dev install)
+RUN apk add --update --no-cache python3-dev=~3.11 gcc musl-dev \
+    librdkafka-dev=~2.1.1
+RUN pip3 install confluent-kafka==2.1.1
+
 COPY rat_server/requirements.txt /wd/
 RUN pip3 install -r /wd/requirements.txt && mkdir -p /etc/xdg/fbrat
 COPY config/ratapi.conf /etc/xdg/fbrat/

--- a/worker/Dockerfile.preinstall
+++ b/worker/Dockerfile.preinstall
@@ -17,8 +17,11 @@ py3-click py3-click-plugins py3-wcwidth py3-six py3-tz tzdata \
 # heatmap adds
 imagemagick zip
 
-RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-    py3-confluent-kafka
+# Installing Confluent Kafka Python client. Eventually, hopefully, it will be
+# installed as Alpine package (thus not requiring gcc and musl-dev install)
+RUN apk add --update --no-cache python3-dev=~3.11 gcc musl-dev \
+    librdkafka-dev=~2.1.1
+RUN pip3 install confluent-kafka==2.1.1
 
 COPY worker/requirements.txt /wd/
 RUN pip3 install --root-user-action=ignore -r /wd/requirements.txt


### PR DESCRIPTION
Alpine module for confluent-kafka became irrelevant, hence in all pertinent dockerfiles its installation was changed from module install to librdkafka odue install and pip-install of confluent-kafka