### PR TITLE
43. Fixed ALS Siphon build failure

### DIFF
--- a/tests/regression/regression.sh
+++ b/tests/regression/regression.sh
@@ -159,7 +159,7 @@ build_dev_server() {
   docker_build_and_push ${wd}/rat_server/Dockerfile ${SRV}:${tag}  ${push} "${EXT_ARGS}"
 
   # build ALS-related images
-  docker_build_and_push Dockerfile.siphon ${ALS_SIPHON}:${tag} ${push} &
+  docker_build_and_push ${wd}/als/Dockerfile.siphon ${ALS_SIPHON}:${tag} ${push} &
   cd ${wd}/als && docker_build_and_push Dockerfile.kafka ${ALS_KAFKA}:${tag} ${push} &
   cd ${wd}/bulk_postgres && docker_build_and_push Dockerfile ${BULK_POSTGRES}:${tag} ${push} &
   cd ${wd}


### PR DESCRIPTION
In recent changes build directory of ALS Siphon image was changed frol als to source files' root, which was not properly reflected in tests/regression/regression.sh This RB fixes the problem