### PR TITLE
58. Moving some helm/bin scripts' command line parameters to YAML files

### DIFF
--- a/helm/afc-ext/values.yaml
+++ b/helm/afc-ext/values.yaml
@@ -24,6 +24,9 @@ externalIps:
 # Dictionary of image repositories. Keys may be any - they are used in
 # component definition. Fields are:
 # path Repository path
+# pushPath Repsoitory to push images to (default is same as 'path'). This field
+# is used by image push script, not by helmcharts and most likely be defined in
+# site-specific values.yaml override
 # pullSecrets List of names of pull secrets
 imageRepositories:
   public:

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -26,6 +26,9 @@ externalIps:
 # Dictionary of image repositories. Keys may be any - they are used in
 # component definition. Fields are:
 # path Repository path
+# pushPath Repsoitory to push images to (default is same as 'path'). This field
+# is used by image push script, not by helmcharts and most likely be defined in
+# site-specific values.yaml override
 # pullSecrets List of names of pull secrets
 imageRepositories:
   public:

--- a/helm/bin/install_prerequisites.yaml
+++ b/helm/bin/install_prerequisites.yaml
@@ -7,6 +7,11 @@
 ---
 # Parameters for install_prerequisites.py
 
+# Default list of components (keys of 'install_components' dictionary) to
+# install/uninstall. Can be overridden in e.g. YAML file, passed via
+# --extra_cfg parameter)
+default_install_components: []
+
 # Dictionary of components (helmcharts and manifests) that might be installed.
 # Keys used in install_prerequisites.py command lines to chose what to install.
 # Entries better be in recommended install order (e.g. because parametyerless


### PR DESCRIPTION
Done to accommodate site-specific scripts' restructuring:
- Announced that push image repositories may be defined in (overrides of) in values.yaml
- List of prerequisites to install may be defined in override of install_prerequisites.yaml
- Script-only (install-only) components are allowed in install_prerequisites.yaml