### PR TITLE
69. Graceful shutdown enhancement

### DIFF
--- a/msghnd/entrypoint.sh
+++ b/msghnd/entrypoint.sh
@@ -30,7 +30,7 @@ case "$AFC_DEVEL_ENV" in
     ;;
 esac
 
-gunicorn \
+exec gunicorn \
 --bind "${AFC_MSGHND_BIND}:${AFC_MSGHND_PORT}" \
 --pid "${AFC_MSGHND_PID}" \
 --workers "${AFC_MSGHND_WORKERS}" \

--- a/rat_server/entrypoint.sh
+++ b/rat_server/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-echo "httpd $HTTPD_OPTIONS -DFOREGROUND >"
-httpd $HTTPD_OPTIONS -DFOREGROUND &
-#
-postfix start
-sleep infinity
+postfix start &
 
-exit $?
+echo "httpd $HTTPD_OPTIONS -DFOREGROUND >"
+exec httpd $HTTPD_OPTIONS -DFOREGROUND


### PR DESCRIPTION
Several services not able to handle TERM signal correctly in the current Dockerfile entrypoint script implementation so that containers are directly killed.    

Msghnd, Worker and Rat-server entrypoint.sh are enhanced for supporting graceful shutdown.  
Testing info please refer to https://github.com/open-afc-project/openafc/issues/69