### PR TITLE
62. Add optional dispatcher passthroughs for Grafana and Prometheus

### DIFF
--- a/dispatcher/Dockerfile
+++ b/dispatcher/Dockerfile
@@ -56,6 +56,21 @@ ENV AFC_ENFORCE_MTLS=${AFC_ENFORCE_MTLS:-false}
 ENV AFC_PROXY_CONN_TOUT=${AFC_PROXY_CONN_TOUT:-720}
 #
 ENV AFC_DEVEL_ENV=${AFC_DEVEL_ENV:-production}
+
+# 'true' to enable access to Prometheus via dispatcher
+ENV AFC_PROMETHEUS_ENABLED=false
+# Host and port of Prometheus server
+ENV AFC_PROMETHEUS_TARGET=prometheus:9090
+# Path on Prometheus server (if not empty - must start with /)
+ENV AFC_PROMETHEUS_PATH=
+
+# 'true' to enable access to Grafana via dispatcher
+ENV AFC_GRAFANA_ENABLED=false
+# Host and port of Grafana server
+ENV AFC_GRAFANA_TARGET=grafana:3000
+# Path on Grafana server (if not empty - must start with /)
+ENV AFC_GRAFANA_PATH=
+
 COPY dispatcher/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 CMD ["/entrypoint.sh"]

--- a/dispatcher/nginx.conf.template
+++ b/dispatcher/nginx.conf.template
@@ -208,6 +208,38 @@ http {
         }
     }
 
+    upstream prometheus {
+        server ${AFC_PROMETHEUS_TARGET};
+    }
+
+    # Prometheus forwarding
+    server {
+        listen 9090;
+        set $prometheus_enabled "${AFC_PROMETHEUS_ENABLED}";
+        if ($prometheus_enabled != true) {
+            return 501;
+        }
+        location / {
+            proxy_pass http://prometheus${AFC_PROMETHEUS_PATH}$request_uri;
+        }
+    }
+
+    upstream grafana {
+        server ${AFC_GRAFANA_TARGET};
+    }
+
+    # Grafana forwarding
+    server {
+        listen 3000;
+        set $grafana_enabled "${AFC_GRAFANA_ENABLED}";
+        if ($grafana_enabled != true) {
+            return 501;
+        }
+        location / {
+            proxy_pass http://grafana${AFC_GRAFANA_PATH}$request_uri;
+        }
+    }
+
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 

--- a/helm/afc-ext/values.yaml
+++ b/helm/afc-ext/values.yaml
@@ -169,6 +169,12 @@ components:
       AFC_OBJST_PORT: "80"
       BROKER_FQDN: "{{ip:int-rmq}}"
       BROKER_PORT: 5672
+      AFC_PROMETHEUS_TARGET: >-
+          {{ip:int-ingress}}:9090
+      AFC_PROMETHEUS_PATH: /prometheus
+      AFC_GRAFANA_TARGET: >-
+          {{ip:int-ingress}}:3000
+      AFC_GRAFANA_PATH: /grafana
     ports:
       http:
         servicePort: 80
@@ -176,6 +182,10 @@ components:
         servicePort: 443
       status:
         servicePort: 8080
+      disp-prometheus:
+        servicePort: 9090
+      disp-grafana:
+        servicePort: 3000
 
 # Dictionary of secret store descriptors
 # Keys used as secret store name (after conversion to RFC1123)

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -304,6 +304,12 @@ components:
         nodePort: 30443
       status:
         servicePort: 8080
+      disp-prometheus:
+        servicePort: 9090
+        nodePort: 31091
+      disp-grafana:
+        servicePort: 3000
+        nodePort: 31001
   rat-server:
     imageName: afc-server
     imageRepositoryKey: private
@@ -626,28 +632,33 @@ components:
 # Properties are
 #   annotations
 #   ingressClassName Value for spec.ingressClassName
-#   rules List of path descriptors. Each descriptor has properties:
-#     name Ingress name
-#     componentKey Index in components
-#     portKey Index in components[componentKey].ports
-#     path Path to match
+#   rules Dictionary of path descriptors, indexed by path. Path descriptors
+#           have the following properties
 #     pathType (Prefix, ImplementationSpecific or Exact). Default is Prefix
+#     componentKey Index in components (not used if 'service' is specified)
+#     portKey Index in components[componentKey].ports. Only used if
+#             'componentKey' is specified
+#     serviceName Explicitly specified host name
+#     portNumber Explicitly specified port number
 ingress:
   name: ingress-int
   ingressClassName: nginx
   rules:
-    - componentKey: msghnd
+    /fbrat/ap-afc/availableSpectrumInquiry:
+      componentKey: msghnd
       portKey: msghnd
-      path: /fbrat/ap-afc/availableSpectrumInquiry
-      pathType: Prefix
-    - componentKey: rat-server
+    /fbrat/ap-afc/availableSpectrumInquirySec:
+      componentKey: msghnd
+      portKey: msghnd
+    /fbrat/ratapi:
+      componentKey: rat-server
       portKey: rat-server
-      path: /fbrat
-      pathType: Prefix
-    - componentKey: objst
+    /certificate:
+      componentKey: objst
       portKey: fileStorage
-      path: /certificate
-      pathType: Prefix
+    /grafana:
+      componentKey: grafana
+      portKey: grafana
 
 # Dictionary of secret store descriptors
 # Keys used as secret store name (after conversion to RFC1123)

--- a/helm/monitoring/prometheus_ingress/prometheus-ingress.yaml
+++ b/helm/monitoring/prometheus_ingress/prometheus-ingress.yaml
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Exposes Prometheus over 
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-ingress
+  labels:
+    app.kubernetes.io/name: prometheus-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /prometheus
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus-operated
+                port:
+                  number: 9090

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,4 +7,4 @@ numpy>=1.12.1
 requests==2.31.0
 openpyxl==3.0.9
 ordered-set==4.1.0
-deepdiff==5.8.1
+deepdiff>=6.6.0


### PR DESCRIPTION
- In dispatcher passthroughs added for Grafana and Prometheus on ports 3000 and 9090 respectively. They are controlled by environment variables:
  - AFC_PROMETHEUS/GRAFANA_TARGET - host/service name:port
  - AFC_PROMETHEUS/GRAFANA_PATH - path to root (may be nontrivial if target is behind ingress-nginx)
  - AFC_PROMETHEUS/GRAFANA_ENABLED - enabled/disabled (disabled by default)
- These environment variables also added to values.yaml foe internal (k3d) and external (k3d) clusters
- Ingress for Prometheus (that lives in monitoring namespace) added separately (to be installed in monitoring namespace)
- ingress data in values.yaml changed from list of rules to dictionary of rules to facilitate partial overriding. _helpers.tpl changed accordingly
Seemingly works on k3d