### PR TITLE
72. Fixing Kubernetes install problems and bugs

### DIFF
--- a/helm/bin/install_prerequisites.py
+++ b/helm/bin/install_prerequisites.py
@@ -19,7 +19,7 @@ import os
 import re
 import sys
 import time
-from typing import Any, cast, Dict, List, Optional
+from typing import Any, cast, Dict, List, Optional, Union
 import yaml
 
 from utils import ArgumentParserFromFile, ClusterContext, Duration, error, \
@@ -41,10 +41,12 @@ class InstallComponent:
     name - Component name
 
     Private attributes:
-    _cfg       -- The whole config dictionary
-    _component -- Install component content as dictionary
+    _cfg             -- The whole config dictionary
+    _component       -- Install component content as dictionary
+    _cluster_context -- ClusterContext object
     """
-    def __init__(self, cfg: Dict[str, Any], name: str) -> None:
+    def __init__(self, cfg: Dict[str, Any], name: str,
+                 cluster_context: ClusterContext) -> None:
         """ Constructor
 
         Arguments:
@@ -55,6 +57,7 @@ class InstallComponent:
         self._cfg = cfg
         self.name = name
         self._component = self._cfg[KEY_INSTALL_COMPONENTS][self.name]
+        self._cluster_context = cluster_context
 
     def __getattr__(self, attr: str) -> Any:
         """ Install component attribute retrieval """
@@ -72,34 +75,48 @@ class InstallComponent:
         if isinstance(value, str):
             ret = ""
             prev_end = 0
-            for m in re.finditer(r"\{\{([a-zA-Z0-9_\-.]+)\}\}", value):
+            for m in re.finditer(r"\{\{([a-zA-Z0-9_:\-.]+)\}\}", value):
                 ret += value[prev_end: m.start()]
                 prev_end = m.end()
-                target = self._cfg
-                for attr in m.group(1).split("."):
-                    if isinstance(target, dict):
-                        error_if(
-                            attr not in target,
-                            f"Invalid item reference '{m.group(0)}' in "
-                            f"config: attribute '{attr}' doesn't point to "
-                            f"existing item")
-                        target = target[attr]
-                    elif isinstance(target, list):
-                        error_if(
-                            not re.match(r"^\d+$", attr),
-                            f"Invalid item reference '{m.group(0)}' in "
-                            f"config: '{attr}' is not a valid list index")
-                        idx = int(attr)
-                        error_if(
-                            not (0 <= idx < len(target)),
-                            f"Invalid item reference '{m.group(0)}' in "
-                            f"config: index '{idx}' is out of range")
-                        target = target[idx]
+                if ":" in m.group(1):
+                    op, params = m.group(1).split(":", maxsplit=1)
+                    if op == "context":
+                        if params == "kubectl":
+                            ret += \
+                                " ".join(self._cluster_context.kubectl_args())
+                        elif params == "helm":
+                            ret += \
+                                " ".join(self._cluster_context.helm_args())
+                        else:
+                            error(f"Unknown context format: {m.group(0)}")
                     else:
-                        error(
-                            f"Invalid item reference '{m.group(0)}' in "
-                            f"config: '{attr}' addresses nothing")
-                ret += str(target)
+                        error(f"Unknown expression: {m.group(0)}")
+                else:
+                    target = self._cfg
+                    for attr in m.group(1).split("."):
+                        if isinstance(target, dict):
+                            error_if(
+                                attr not in target,
+                                f"Invalid item reference '{m.group(0)}' in "
+                                f"config: attribute '{attr}' doesn't point to "
+                                f"existing item")
+                            target = target[attr]
+                        elif isinstance(target, list):
+                            error_if(
+                                not re.match(r"^\d+$", attr),
+                                f"Invalid item reference '{m.group(0)}' in "
+                                f"config: '{attr}' is not a valid list index")
+                            idx = int(attr)
+                            error_if(
+                                not (0 <= idx < len(target)),
+                                f"Invalid item reference '{m.group(0)}' in "
+                                f"config: index '{idx}' is out of range")
+                            target = target[idx]
+                        else:
+                            error(
+                                f"Invalid item reference '{m.group(0)}' in "
+                                f"config: '{attr}' addresses nothing")
+                    ret += str(target)
             ret += value[prev_end: len(value)]
             return ret
         return value
@@ -133,19 +150,41 @@ class InstallHandler(abc.ABC):
 
     def install(self) -> None:
         """ Performs installation. Base implementation contains common part """
-        print(f">>> Installing: {self._component.name}")
-        if self._component_installed():
-            print("Component already installed, skipping installation")
+        attempts = getattr(self._component, "attempts", 1)
+        for attempt in range(attempts):
+            print(f">>> Installing: {self._component.name}. "
+                  f"Attempt {attempt + 1} of {attempts}")
+            if self._component_installed():
+                print("Component already installed, skipping installation")
+                return
+            install_wait = \
+                Duration(getattr(self._component, "install_wait", None))
+            deadline: Optional[datetime.datetime] = \
+                (datetime.datetime.now() +
+                 datetime.timedelta(
+                     seconds=cast(Union[int, float],
+                                  install_wait.seconds()))) \
+                if install_wait else None
+            if not self._preinstall_impl():
+                continue
+            for cmd in getattr(self._component, "preinstall", []):
+                result = execute(cmd.lstrip("-"), fail_on_error=False)
+                if (not result) and (not cmd.startswith("-")):
+                    continue
+            if self._is_new_namespace and (not self._namespace_exists()):
+                assert isinstance(self._namespace, str)
+                execute(["kubectl", "create", "namespace", self._namespace] +
+                        self._cluster_context.kubectl_args())
+            if not self._install_impl():
+                continue
+            for cmd in getattr(self._component, "postinstall", []):
+                result = execute(cmd.lstrip("-"), fail_on_error=False)
+                if (not result) and (not cmd.startswith("-")):
+                    continue
+            if not self._wait_for_pod(deadline):
+                continue
             return
-        for cmd in getattr(self._component, "preinstall", []):
-            execute(cmd.lstrip("-"), fail_on_error=not cmd.startswith("-"))
-        if self._is_new_namespace and (not self._namespace_exists()):
-            assert isinstance(self._namespace, str)
-            execute(["kubectl", "create", "namespace", self._namespace] +
-                    self._cluster_context.kubectl_args())
-        self._install_impl()
-        for cmd in getattr(self._component, "postinstall", []):
-            execute(cmd.lstrip("-"), fail_on_error=not cmd.startswith("-"))
+        error("Execution failed")
 
     def uninstall(self) -> None:
         """ Perform uninstallation """
@@ -171,13 +210,52 @@ class InstallHandler(abc.ABC):
         return Duration(getattr(self._component, "uninstall_wait", None)).\
             kubectl_timeout()
 
+    def _wait_for_pod(self, deadline: Optional[datetime.datetime]) -> bool:
+        """ If component should waiyt for pod readiness on installation - do it
+        """
+        wait_pod = getattr(self._component, "wait_pod", None)
+        if not wait_pod:
+            return True
+        error_if(deadline is None,
+                 "'wait_pod' requires 'install_wait' to be specified")
+        assert deadline is not None
+        print(f"Waiting for pod '{wait_pod}*' to be ready")
+        while True:
+            if deadline <= datetime.datetime.now():
+                print("Timeout expired", file=sys.stderr)
+                return False
+            pod_infos: List[Dict[str, Any]] = \
+                [pod_info for pod_info in
+                 parse_json_output(
+                     ["kubectl", "get", "pods", "-o", "json"] +
+                     self._cluster_context.kubectl_args(
+                         namespace=self._namespace),
+                     echo=False)["items"]
+                 if pod_info["metadata"]["name"].startswith(wait_pod)]
+            error_if(len(pod_infos) > 1,
+                     f"More than one pod with name starting with '{wait_pod}' "
+                     f"found")
+            if (len(pod_infos) == 1) and \
+                    all(cs.get("ready") for cs in
+                        pod_infos[0].get("status", {}).
+                        get("containerStatuses", [])):
+                break
+            time.sleep(10)
+        return True
+
     def _component_installed(self) -> bool:
         """ True if component known to be installed """
         return False
 
+    def _preinstall_impl(self) -> bool:
+        """ Class-specific preinstallation operations
+        Returns True on success, False on fail """
+        return True
+
     @abc.abstractmethod
-    def _install_impl(self) -> None:
-        """ Class-specific installation operations """
+    def _install_impl(self) -> bool:
+        """ Class-specific installation operations
+        Returns True on success, False on fail """
         ...
 
     @abc.abstractmethod
@@ -219,11 +297,16 @@ class InstallHandler(abc.ABC):
 class ManifestInstallHandler(InstallHandler):
     """ Installs/uninstalls manifest component """
 
-    def _install_impl(self) -> None:
-        """ Class-specific installation operations """
-        execute(
-            ["kubectl", "create", "-f", self._manifest_name()] +
-            self._cluster_context.kubectl_args(namespace=self._namespace))
+    def _install_impl(self) -> bool:
+        """ Class-specific installation operations
+        Returns True on success, False on fail
+        """
+        if not execute(["kubectl", "create", "-f", self._manifest_name()] +
+                       self._cluster_context.kubectl_args(
+                           namespace=self._namespace),
+                       fail_on_error=False):
+            return False
+        return True
 
     def _uninstall_impl(self) -> None:
         """ Class-specific uninstallation operations """
@@ -235,13 +318,14 @@ class ManifestInstallHandler(InstallHandler):
 
     def _component_installed(self) -> bool:
         """ True if component known to be installed """
-        if not hasattr(self._component, "has_service"):
+        if not hasattr(self._component, "manifest_check"):
             return False
         return \
             cast(bool,
                  execute(
-                     ["kubectl", "get", "service",
-                      self._component.has_service] +
+                     ["kubectl", "get",
+                      self._component.manifest_check["kind"],
+                      self._component.manifest_check["name"]] +
                      self._cluster_context.kubectl_args(
                          namespace=self._namespace),
                      fail_on_error=False, hide_stderr=True))
@@ -254,11 +338,9 @@ class ManifestInstallHandler(InstallHandler):
 class HelmInstallHandler(InstallHandler):
     """ Installs/uninstalls helm install item """
 
-    def _install_impl(self) -> None:
-        """ Class-specific installation operations """
-        error_if(not hasattr(self._component, "helm_release"),
-                 f"'helm_release' should be specified for component "
-                 f"'{self._component.name}'")
+    def _preinstall_impl(self) -> bool:
+        """ Class-specific preinstallation operations
+        Returns True on success, False on fail """
         helmchart = self._component.helm_chart
         if hasattr(self._component, "helm_repo"):
             m = re.match("^(.+?)/", helmchart)
@@ -269,7 +351,17 @@ class HelmInstallHandler(InstallHandler):
             execute(["helm", "repo", "add", m.group(1),
                      self._component.helm_repo])
             execute(["helm", "repo", "update"])
-        else:
+        return True
+
+    def _install_impl(self) -> bool:
+        """ Class-specific installation operations
+       Returns True on success, False on fail
+       """
+        error_if(not hasattr(self._component, "helm_release"),
+                 f"'helm_release' should be specified for component "
+                 f"'{self._component.name}'")
+        helmchart = self._component.helm_chart
+        if not hasattr(self._component, "helm_repo"):
             helmchart = expand_filename(helmchart, root=SCRIPTS_DIR)
         helm_args = \
             ["helm", "upgrade", "--install", self._component.helm_release,
@@ -285,7 +377,7 @@ class HelmInstallHandler(InstallHandler):
         helm_args += getattr(self._component, "args", []) + \
             Duration(getattr(self._component, "helm_wait", None)).\
             helm_timeout()
-        execute(helm_args)
+        return cast(bool, execute(helm_args, fail_on_error=False))
 
     def _uninstall_impl(self) -> None:
         """ Class-specific uninstallation operations """
@@ -326,26 +418,28 @@ class HelmInstallHandler(InstallHandler):
                         f"'{self._component.name}'")
                     time.sleep(5)
 
-    # def _component_installed(self) -> bool:
-    #     """ True if component known to be installed """
-    #     installed_charts = \
-    #         parse_json_output(
-    #             ["helm", "list", "-o", "json"] +
-    #             self._cluster_context.helm_args(namespace=self._namespace))
-    #     return any(chartinfo.get("name") == self._component.helm_release
-    #                for chartinfo in installed_charts)
+    def _component_installed(self) -> bool:
+        """ True if component known to be installed """
+        installed_charts = \
+            parse_json_output(
+                ["helm", "list", "-o", "json"] +
+                self._cluster_context.helm_args(namespace=self._namespace))
+        return any(chartinfo.get("name") == self._component.helm_release
+                   for chartinfo in installed_charts)
 
 
 class DummyInstallHandler(InstallHandler):
     """ Installs/uninstalls dummy (neither of the above) component """
 
-    def _install_impl(self) -> None:
-        """ Class-specific installation operations """
-        pass
+    def _install_impl(self) -> bool:
+        """ Class-specific installation operations
+        Returns True on success, False on fail
+        """
+        return True
 
     def _uninstall_impl(self) -> None:
         """ Class-specific uninstallation operations """
-        pass
+        ...
 
 
 def recursive_merge(base: Any, override: Any) -> Any:
@@ -469,14 +563,16 @@ def main(argv: List[str]) -> None:
                 (len(install_list) - 1) if args.uninstall else 0,
                 -1 if args.uninstall else len(install_list),
                 -1 if args.uninstall else 1):
-        component = InstallComponent(cfg=cfg, name=install_list[item_idx])
+        component = InstallComponent(cfg=cfg, name=install_list[item_idx],
+                                     cluster_context=cluster_context)
         namespace: Optional[str] = getattr(component, "namespace", None)
         install_handler = \
             InstallHandler.create(
                 component=component,
                 is_new_namespace=bool(namespace) and
                 (not any(
-                    getattr(InstallComponent(cfg=cfg, name=install_list[i]),
+                    getattr(InstallComponent(cfg=cfg, name=install_list[i],
+                                             cluster_context=cluster_context),
                             "namespace", None) == namespace
                     for i in range(item_idx))),
                 cluster_context=cluster_context)

--- a/helm/bin/install_prerequisites.yaml
+++ b/helm/bin/install_prerequisites.yaml
@@ -18,6 +18,7 @@ default_install_components: []
 # uninstall uninstall components in reverse order)
 # Dictionary values may have the following properties:
 #   - namespace. Namespace to install manifests/helmcharts in
+#   - attempts. Number of attempts to make (default is 1)
 #   - preinstall. List of commands to perform before kubernetes/helm
 #             installation. Commands that starts with `-` - not checked for
 #             failure. Executed from checkout root directory
@@ -27,8 +28,11 @@ default_install_components: []
 #   - manifest. Path or URL to manifest file or directory. Path may use ~ and
 #             $. Relative paths are from script's directory'
 #   - manifest_url. URL to manifest file or directory
-#   - has_service. Name of service installed by manifest of this step. If
-#             present - installation is skipped
+#   - manifest_check. Manifest considered installed if this entity present:
+#       - kind Entity kind
+#       - name Entity name
+#   - wait_pod Initial part of pod name to wait for on manifest or helm
+#             installation
 #   - helm_chart. Helmchart to install if filename - relative to script's
 #             directory
 #   - helm_release. Helm release name
@@ -37,39 +41,45 @@ default_install_components: []
 #             directory. May use ~ and environment variables
 #   - helm_settings: List of value settings
 #   - helm_version. Helmchart version specifier
-#   - helm_wait. How long to wait for helm install install
+#   - install_wait. How long to wait for installation completion
 #   - uninstall_wait. How long to wait for helm/kubectl uninstall
 #
-# Property values may contain references to content of other places in config
-# file in form {{attr1.attr2....}}. Here attrN is a sequence of
-# attributes to reach target value.
-# E.g. if there is ip.yaml file containing ip address dictionary externalIps
-# (see values.yaml for details) and command line has --extra_cfg ip.yaml then
-# {{externalIps.int-ingress}} in some value will be substituted with
-# corresponding IP address. This feature was introduced to access IPs in AFC
-# helmchart in values.yaml override of ingress-nginx
+# Property values may contain {{...}} inserts of the following forms:
+#   - {{ATTR1.ATTR2....}} - sequence of attributes to reach some value in
+#             consolidated config file. Sample usage is to include (with
+#             --extra_cfg) values.yaml override with external IPs and then
+#             refer values from there as {{externalIps.int-ingress}}
+#   - {{context:FORMAT}} Where FORMAT is either 'kubectl' or 'helm'. This is
+#             rendered as contetx arguments in kubectl or helm form
 install_components:
   prometheus_operator:
     manifest: >-
       https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.72.0/bundle.yaml
-    has_service: prometheus-operator
+    manifest_check:
+      kind: service
+      name: prometheus-operator
+    wait_pod: prometheus-operator
+    install_wait: 5m
     uninstall_wait: 5m
   prometheus:
     namespace: monitoring
     manifest: ../monitoring/prometheus
-    has_service: prometheus-operated
+    manifest_check:
+      kind: service
+      name: prometheus-operated
     uninstall_wait: 5m
   prometheus_adapter:
     namespace: monitoring
     preinstall:
-      - -kubectl delete apiservice v1beta1.metrics.k8s.io --wait --force -A
+      - >-
+        -kubectl delete apiservice v1beta1.metrics.k8s.io {{context:kubectl}} -A
     helm_chart: prometheus-community/prometheus-adapter
     helm_repo: https://prometheus-community.github.io/helm-charts
     helm_release: custom-metrics
     helm_values:
       - ../monitoring/prometheus_adapter/values-prometheus_adapter.yaml
     helm_version: 2.14.2
-    helm_wait: 5m
+    install_wait: 5m
     uninstall_wait: 5m
   external_secrets:
     namespace: external-secrets
@@ -78,12 +88,21 @@ install_components:
     helm_release: external-secrets
     helm_settings:
       - installCRDs=true
-    helm_wait: 5m
+    wait_pod: external-secrets-webhook
+    install_wait: 5m
     uninstall_wait: 5m
   ingress_nginx:
     namespace: ingress-nginx
     helm_chart: ingress-nginx/ingress-nginx
     helm_repo: https://kubernetes.github.io/ingress-nginx
     helm_release: ingress-nginx
-    helm_wait: 5m
+    install_wait: 5m
+    wait_pod: ingress-nginx-controller
     uninstall_wait: 5m
+  prometheus_ingress:
+    namespace: monitoring
+    manifest: ../monitoring/prometheus_ingress
+    uninstall_wait: 5m
+    manifest_check:
+      kind: ingress
+      name: prometheus-ingress

--- a/helm/bin/k3d_registry.py
+++ b/helm/bin/k3d_registry.py
@@ -53,7 +53,7 @@ def main(argv: List[str]) -> None:
             else:
                 print(f"Registry '{args.registry}' is not currently running")
         elif len(registries) == 0:
-            print("Nothing to do")
+            print("No registries currently running")
         else:
             error_if((len(registries) > 1) and (not args.force),
                      "More than one registy running. Specify name of registry "
@@ -69,7 +69,7 @@ def main(argv: List[str]) -> None:
             execute(["k3d", "registry", "create", args.registry])
         else:
             if registries:
-                print("Nothing to do")
+                print("Registry is currently running")
             else:
                 execute(["k3d", "registry", "create",
                          args.registry or DEFAULT_REGISTRY_NAME])

--- a/helm/bin/utils.py
+++ b/helm/bin/utils.py
@@ -433,6 +433,7 @@ class Duration:
         "y": 3600 * 24 * 365.25}
 
     def __init__(self, duration: Optional[Union[str, int, float]]) -> None:
+        """ Constructs from seconds or Go duration """
         self._seconds: Optional[Union[float, int]]
         if duration is None:
             self._seconds = None


### PR DESCRIPTION
- helm installation reordered so that `helm install` immediately follows `preinstall`. This allow to install prometheus adaadapter before resurrection of removed metrics apiservice 
- `attempts` - used in prometheus-adapter indtallation to kope with resurrection of metrics apiservice
- `has_service` renamed to `manifest_check` to check for anything (not necessary service) - used in installation of prometheus_ingress
- `helm_wait` renamed to `install_wait' to wait for manifest installation
- {{context:kubectl}} used in kubectl preinstall/postinstall clauese