### PR TITLE
83. Crash dispatcher if nginx not started

### DIFF
--- a/dispatcher/Dockerfile
+++ b/dispatcher/Dockerfile
@@ -6,7 +6,7 @@
 #
 FROM nginx:1.24.0-alpine
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 \
+RUN apk add --update --no-cache python3 py3-psutil \
     && ln -sf python3 /usr/bin/python \
     && python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade \
@@ -74,4 +74,5 @@ COPY dispatcher/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 CMD ["/entrypoint.sh"]
 HEALTHCHECK --start-period=60s --interval=30s --retries=1 \
-    CMD curl --fail http://localhost/fbrat/ap-afc/healthy || exit 1
+    CMD curl --fail http://localhost/fbrat/ap-afc/healthy && \
+    /wd/acceptor.py --cmd check || exit 1

--- a/dispatcher/acceptor.py
+++ b/dispatcher/acceptor.py
@@ -22,8 +22,10 @@ from logging.config import dictConfig
 import argparse
 import inspect
 import gevent
+import psutil
 import subprocess
 import shutil
+import time
 from ncli import MsgAcceptor
 from hchecks import MsghndHealthcheck, ObjstHealthcheck
 from fst import DataIf
@@ -50,6 +52,8 @@ dictConfig({
     },
 })
 app_log = logging.getLogger()
+
+NGINX_BIN = os.environ.get("NGINX_BIN", "nginx")
 
 
 class Configurator(dict):
@@ -93,6 +97,9 @@ def readiness_check(cfg):
        list of subjects (containers)
     """
     app_log.debug(f"({os.getpid()}) {inspect.stack()[0][3]}()")
+    if not any(p.name() == NGINX_BIN for p in psutil.process_iter()):
+        app_log.error("Nginx process not running")
+        return 1
     objst_chk = ObjstHealthcheck(cfg)
     msghnd_chk = MsghndHealthcheck.from_hcheck_if()
     checks = [gevent.spawn(objst_chk.healthcheck),
@@ -123,7 +130,7 @@ def run_restart(cfg):
                          f"{cfg['DISPAT_CERT_CLI_BUNDLE_DFLT']}")
             shutil.copy2(cfg['DISPAT_CERT_CLI_BUNDLE_DFLT'],
                          cfg['DISPAT_CERT_CLI_BUNDLE'])
-        p = subprocess.Popen("nginx -s reload",
+        p = subprocess.Popen(f"{NGINX_BIN} -s reload",
                              stdout=subprocess.PIPE, shell=True)
         app_log.info(f"{p.communicate()}")
 
@@ -139,7 +146,7 @@ def run_remove(cfg):
                   f"{cfg['DISPAT_CERT_CLI_BUNDLE_DFLT']}")
     shutil.copy2(cfg['DISPAT_CERT_CLI_BUNDLE_DFLT'],
                  cfg['DISPAT_CERT_CLI_BUNDLE'])
-    p = subprocess.Popen("nginx -s reload",
+    p = subprocess.Popen(f"{NGINX_BIN} -s reload",
                          stdout=subprocess.PIPE, shell=True)
     app_log.info(f"{p.communicate()}")
 
@@ -165,6 +172,13 @@ def run_it(cfg):
                  cfg['DISPAT_CERT_CLI_BUNDLE_DFLT'])
     # check if lucky to find new certificate bundle already
     run_restart(cfg)
+
+    time.sleep(10)
+    if not any(p.name() == NGINX_BIN for p in psutil.process_iter()):
+        app_log.critical(
+            f"Nginx process '{NGINX_BIN} not started or prematurely "
+            f"terminated. Check validity of nginx config files")
+        return 1
 
     maker = MsgAcceptor(cfg['BROKER_URL'], cfg['BROKER_EXCH_DISPAT'],
                         msg_handler=get_commands, handler_params=cfg)

--- a/dispatcher/entrypoint.sh
+++ b/dispatcher/entrypoint.sh
@@ -10,22 +10,22 @@ case "$AFC_DEVEL_ENV" in
   "devel")
     echo "Running debug profile" 
     ACCEPTOR_LOG_LEVEL="--log debug"
-    BIN=nginx-debug
+    export NGINX_BIN=nginx-debug
     apk add --update --no-cache bash
     ;;
   "production")
     echo "Running production profile"
     ACCEPTOR_LOG_LEVEL=
-    BIN=nginx
+    export NGINX_BIN=nginx
     ;;
   *)
     echo "Uknown profile"
     ACCEPTOR_LOG_LEVEL=
-    BIN=nginx
+    export NGINX_BIN=nginx
     ;;
 esac
 
-/docker-entrypoint.sh $BIN -g "daemon off;" &
+/docker-entrypoint.sh $NGINX_BIN -g "daemon off;" &
 
 /wd/acceptor.py $ACCEPTOR_LOG_LEVEL --cmd run
 


### PR DESCRIPTION
- acceptor.py getting nginx binary name in NGINX_BIN environment variables and uses it for:
  - Addressing nginx (e.g. when restarting it)
  - Checking if nginx is running in readiness check procedure
  - Checking if nginx is running at the beginning of run procedure - and crashes dispatcher pod if it is not running
- Healtcheck procedure changed in Dockerfile. It is not actually used in Kubernetes (and ignored in Docker), so it just serves an illustrative purpose