### PR TITLE
94. Revising nginx settings for Grafana and Prometheus

### DIFF
--- a/dispatcher/nginx.conf.template
+++ b/dispatcher/nginx.conf.template
@@ -174,6 +174,8 @@ http {
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy  "script-src 'self' 'unsafe-inline'";
             proxy_pass http://prometheus$request_uri;
             proxy_redirect http:// $scheme://;
         }
@@ -188,7 +190,8 @@ http {
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy  "script-src 'self' 'unsafe-eval' 'unsafe-inline'";
             proxy_pass http://grafana$request_uri;
         }
 
@@ -219,7 +222,7 @@ http {
         }
         add_header X-Content-Type-Options nosniff;
         add_header X-Frame-Options "SAMEORIGIN";
-        add_header Content-Security-Policy  "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://maps.googleapis.com https://code.jquery.com https://netdna.bootstrapcdn.com/bootstrap https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' https://fonts.googleapis.com https://netdna.bootstrapcdn.com https://www.gstatic.com/recaptcha/ 'unsafe-inline'";
+        add_header Content-Security-Policy  "script-src 'self' 'unsafe-eval' https://maps.googleapis.com https://code.jquery.com https://netdna.bootstrapcdn.com/bootstrap https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' https://fonts.googleapis.com https://netdna.bootstrapcdn.com https://www.gstatic.com/recaptcha/ 'unsafe-inline'";
         add_header X-XSS-Protection "1; mode=block";
         add_header Referrer-Policy "strict-origin-when-cross-origin";
         add_header Permissions-Policy "geolocation=(self), microphone=(), camera=(), speaker=(), vibrate=(), payment=(), fullscreen=(self), sync-xhr=(), magnetometer=(), gyroscope=(), accelerometer=(), usb=(), autoplay=(), midi=(), encrypted-media=(), vr=(), xr-spatial-tracking=()";

--- a/helm/afc-int/values-k3d.yaml
+++ b/helm/afc-int/values-k3d.yaml
@@ -13,6 +13,13 @@ components:
   dispatcher:
     service:
       type: NodePort
+  grafana:
+    env:
+      # Somehow Grafana behaves differently when exposed from behind dispatcher
+      # only (k3d) as compared to dispatcher and ingress-nginx (GCE) - hence
+      # this setting. The root cause is probably some dispatcher nginx
+      # configuration issue.
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
 
 ingress: null
 

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -649,11 +649,9 @@ components:
         servicePort: 3000
         nodePort: 31000
     ingress:
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /$2
       rules:
-        - path: /grafana($|/)(.*)
-          pathType: ImplementationSpecific
+        - path: /grafana
+          pathType: Prefix
           portKey: grafana
   nginxexporter:
     imageName: nginxexporter-image

--- a/prometheus/grafana.ini
+++ b/prometheus/grafana.ini
@@ -55,7 +55,7 @@
 root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
 
 # Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
-;serve_from_sub_path = false
+serve_from_sub_path = false
 
 # Log web requests
 ;router_logging = false


### PR DESCRIPTION
'unsafe-inline', recently added to Content-Security-Policy of script-src to expose Prometheus and Grafana moved to Prometheus/Grafana location block to avoid further discussion.

Grafana parameters fixed to make it work both behind Dispatcher-only (k3d) and Dispatcher+ingress-nginx (GCE)