### PR TITLE
99. Increasing ingress-nginx timeout for msghnd

### DIFF
--- a/helm/afc-common/templates/_helpers.tpl
+++ b/helm/afc-common/templates/_helpers.tpl
@@ -823,8 +823,9 @@ Ingress annotations
 {{- define "afc.ingressAnnotations" -}}
 {{- $compDef := merge (dict) (get $.Values.components .component | required (cat "No component for this component key:" .component)) $.Values.components.default -}}
 {{- $ingressDef := get $compDef "ingress" | required (cat "Component" .component "does not have ingress defined") -}}
-{{- range $key, $value := (default (dict) (get $ingressDef "annotations")) }}
-{{ $key }}: {{ $value }}
+{{- $annotations := get $ingressDef "annotations" -}}
+{{- if $annotations }}
+{{    toYaml $annotations }}
 {{- end }}
 {{- end }}
 

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -410,6 +410,13 @@ components:
       - oidc-client-secret
       - rcache-db-password
     ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "720"
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "720"
+        nginx.ingress.kubernetes.io/client-body-timeout: "720"
+        nginx.ingress.kubernetes.io/client-header-timeout: "720"
+        nginx.ingress.kubernetes.io/upstream-keepalive-timeout: "720"
+        nginx.ingress.kubernetes.io/keep-alive: "720"
       rules:
         - path: /fbrat/ap-afc/availableSpectrumInquiry
           portKey: msghnd


### PR DESCRIPTION
- Timeout-related annotations added to ingress parameters of msghnd in values.yaml (unfortunately there is no easy way to parameterize them, so just a relatively long 15 minutes were chosen)
- Ingress annotation rendering bug fixed in _helpers.tpl