### PR TITLE
102 remove anomalous fs rxgain check

### DIFF
--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,4 +1,23 @@
 # Release Note
+
+## **Version and Date**
+|Version|**102*|
+| :- | :- |
+|**Date**|**02/29/2024**|
+
+## **Issues Addressed**
+ * 102: remove-anomalous-fs-rxgain-check
+ * Fixing anomalous FS Rx Gain should be all done by the FS parser during generation of the FS database sqlite3 file. Recently, a bug was found where the afc-engine removed Canadian FS links with FS Rx Gain < 10 dBi. We hadn't seen this in the US AFC since the FS parser implements WinnForum TS 1014 R2-AIP-05 and 06 that ensures FS Rx Gain is at least 32 dBi. However, for Canada, the FS database is assumed to be sanitized already and minimum fix is done by the FS Parser (only if the gain is missing or 0). This check by the afc-engine has now been removed.
+
+## **Interface Changes**
+ * None
+
+## **Testing Done**
+ * Ran a test (see attached afc-config, request and response json files to the issue) and confirmed that the fs_anom.csv file is empty as expected. Previously, this file contained 23 links for this test that were removed due to having Rx Gain of 6 dBi).
+
+## **Open Issues** 
+ * None
+
 ## **Version and Date**
 |Version|1.0.0.0|
 | :- | :- |

--- a/src/afc-engine/AfcManager.cpp
+++ b/src/afc-engine/AfcManager.cpp
@@ -6101,9 +6101,11 @@ void AfcManager::readULSData(
 									numIgnoreInvalid++;
 								}
 							} else {
-								ignoreFlag = true;
-								reasonIgnored = "invalid Rx Gain";
-								numIgnoreInvalid++;
+								// DO NOTHING
+
+								// ignoreFlag = true;
+								// reasonIgnored = "invalid Rx Gain";
+								// numIgnoreInvalid++;
 							}
 						}
 					}

--- a/src/afc-engine/AfcManager.cpp
+++ b/src/afc-engine/AfcManager.cpp
@@ -6104,8 +6104,8 @@ void AfcManager::readULSData(
 								// DO NOTHING
 
 								// ignoreFlag = true;
-								// reasonIgnored = "invalid Rx Gain";
-								// numIgnoreInvalid++;
+								// reasonIgnored = "invalid Rx
+								// Gain"; numIgnoreInvalid++;
 							}
 						}
 					}


### PR DESCRIPTION
Issue 102

Fixing anomalous FS Rx Gain should be all done by the FS parser during generation of the FS database sqlite3 file. Recently, a bug was found where the afc-engine removed Canadian FS links with FS Rx Gain < 10 dBi. We hadn't seen this in the US AFC since the FS parser implements WinnForum TS 1014 R2-AIP-05 and 06 that ensures FS Rx Gain is at least 32 dBi. However, for Canada, the FS database is assumed to be sanitized already and minimum fix is done by the FS Parser (only if the gain is missing or 0). This check by the afc-engine has now been removed.

 Ran a test (see attached afc-config, request and response json files to the issue) and confirmed that the fs_anom.csv file is empty as expected. Previously, this file contained 23 links for this test that were removed due to having Rx Gain of 6 dBi).