### PR TITLE
116. Extract DB/Rcache hardcoded stuff into modules, shareable with new msghnd implementation

### DIFF
--- a/src/afc-packages/afcmodels/afcmodels/__init__.py
+++ b/src/afc-packages/afcmodels/afcmodels/__init__.py
@@ -1,1 +1,0 @@
-from . import base, aaa, hardcoded_relations

--- a/src/afc-packages/afcmodels/afcmodels/__init__.py
+++ b/src/afc-packages/afcmodels/afcmodels/__init__.py
@@ -1,1 +1,1 @@
-from . import base, aaa
+from . import base, aaa, hardcoded_relations

--- a/src/afc-packages/afcmodels/afcmodels/aaa.py
+++ b/src/afc-packages/afcmodels/afcmodels/aaa.py
@@ -101,14 +101,13 @@ class CertId(db.Model):
     ''' entry to designate allowed AP's for the PAWS interface '''
 
     __tablename__ = 'cert_id'
-    UNKNOWN = 0
-    OUTDOOR = 2
-    INDOOR = 1
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     certification_id = db.Column(db.String(64), nullable=False)
     refreshed_at = db.Column(db.DateTime())
     ruleset_id = db.Column(db.Integer, db.ForeignKey(
         'aaa_ruleset.id', ondelete='CASCADE'), nullable=False)
+    # Bits for this field defined by hardcoded_relations.CERT_ID_LOCATION_...
+    # constants
     location = db.Column(db.Integer, nullable=False)
 
     def __init__(self, certification_id, location):

--- a/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
+++ b/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
@@ -10,6 +10,7 @@ from typing import Dict, List, NamedTuple, Optional, Set
 
 from . import aaa
 
+
 class RulesetVsRegion:
     """ Translations between Ruleset IDs and Afc Config's region strings """
     # Domain (region) descriptotr as stored internally
@@ -126,7 +127,7 @@ class SpecialCertifications:
 
     # Certificate dictionary. Initialized on first call to class methods
     _special_certificates: Dict["SpecialCertifications._Key",
-                              "SpecialCertifications.Properties"] = {}
+                               "SpecialCertifications.Properties"] = {}
 
     @classmethod
     def get_properties(cls, cert_id: str, serial_number: str) \
@@ -141,10 +142,10 @@ class SpecialCertifications:
         if cls._special_certificates:
             return
         for cert_id, serial_number, location_flags in \
-               [("TestCertificationId", "TestSerialNumber",
-                 aaa.CertId.OUTDOOR | aaa.CertId.INDOOR),
-                ("HeatMapCertificationId", "HeatMapSerialNumber",
-                 aaa.CertId.OUTDOOR | aaa.CertId.INDOOR)]:
+                [("TestCertificationId", "TestSerialNumber",
+                  aaa.CertId.OUTDOOR | aaa.CertId.INDOOR),
+                 ("HeatMapCertificationId", "HeatMapSerialNumber",
+                  aaa.CertId.OUTDOOR | aaa.CertId.INDOOR)]:
             key = cls._Key(cert_id=cert_id, serial_number=serial_number)
             assert key not in cls._special_certificates
             cls._special_certificates[key] = \

--- a/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
+++ b/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
@@ -1,0 +1,280 @@
+""" Hardcoded relations that eventually may go to some DB """
+#
+# Copyright (C) 2023 Broadcom. All rights reserved. The term "Broadcom"
+# refers solely to the Broadcom Inc. corporate affiliate that owns
+# the software below. This work is licensed under the OpenAFC Project License,
+# a copy of which is included with this software program
+#
+
+from typing import Dict, List, NamedTuple, Optional, Set
+
+from . import aaa
+
+class RulesetVsRegion:
+    """ Translations between Ruleset IDs and Afc Config's region strings """
+    # Domain (region) descriptotr as stored internally
+    _DomainDsc = \
+        NamedTuple(
+            "_DomainDsc",
+            [
+             # AFC Config region string
+             ("region", str),
+             # AFC Request Ruleset ID
+             ("ruleset", str),
+             # True for base (specified in constructor) domain, False for
+             # derived
+             ("is_base", bool),
+             # True to provide in list function
+             ("is_listable", bool),
+             # None or string to overwrite region string in config being sent
+             # to AFC Engine
+             ("overwrite_region", Optional[str])])
+
+    # Domain descriptors by ruleset ID. Initialized on first class method
+    # invocation
+    _by_ruleset: Dict[str, "RulesetVsRegion._DomainDsc"] = {}
+
+    # Domain descriptors by AFC Config region string. Initialized on first
+    # class method invocation
+    _by_region: Dict[str, "RulesetVsRegion._DomainDsc"] = {}
+
+    @classmethod
+    def base_region_list(cls) -> List[str]:
+        """ List of listable base (nonderived) AFC Region strings """
+        cls._initialize()
+        return [r for r, dd in cls._by_region.iyems() if dd.is_base]
+
+    @classmethod
+    def region_list(cls) -> List[str]:
+        """ List of listable AFC Region strings """
+        cls._initialize()
+        return [r for r, dd in cls._by_region.items() if dd.is_listable]
+
+    @classmethod
+    def ruleset_list(cls) -> List[str]:
+        """ List of listable Ruleset ID strings """
+        cls._initialize()
+        return [r for r, dd in cls._by_ruleset.items() if dd.is_listable]
+
+    @classmethod
+    def region_to_ruleset(cls, region: str, exc: Exception) -> str:
+        """ Returns Ruleset ID for given AFC Config region string.
+        Generates exception of given type is not found """
+        cls._initialize()
+        try:
+            return cls._by_region[region].ruleset
+        except KeyError:
+            raise exc(f"Invalid region name '{region}'")
+
+    @classmethod
+    def ruleset_to_region(cls, ruleset: str, exc: Exception) -> str:
+        """ Returns AFC Config region string for given Ruleset ID.
+        Generates exception of given type is not found """
+        cls._initialize()
+        try:
+            return cls._by_ruleset[ruleset].region
+        except KeyError:
+            raise exc(f"Invalid ruleset ID '{ruleset}'")
+
+    @classmethod
+    def overwrite_region(cls, region: str, exc: Exception) -> Optional[str]:
+        """ Returns None or AFC Region string to use in AFC Config to send to\
+        AFC Engine. Generates exception of given type is not found """
+        cls._initialize()
+        try:
+            return cls._by_region[region].overwrite_region
+        except KeyError:
+            raise exc(f"Invalid region name '{region}'")
+
+    @classmethod
+    def _initialize(cls) -> None:
+        """ Initializes dictionaries on first call """
+        if cls._by_region and cls._by_ruleset:
+            return
+        base_domains = \
+            [("US", "US_47_CFR_PART_15_SUBPART_E"),  # First is 'DEFAULT'
+             ("CA", "CA_RES_DBS-06"),
+             ("BR", "BRAZIL_RULESETID"),
+             ("GB", "UNITEDKINGDOM_RULESETID")]
+        for idx, (region, ruleset) in enumerate(base_domains):
+            assert ruleset not in cls._by_ruleset
+            assert region not in cls._by_region
+            cls._by_ruleset[ruleset] = cls._by_region[region] = \
+                RulesetVsRegion._DomainDsc(
+                    region=region, ruleset=ruleset, is_base=True,
+                    is_listable=True, overwrite_region=None)
+            for prefix in ("TEST_", "DEMO_"):
+                cls._by_ruleset[prefix + ruleset] = \
+                    cls._by_region[prefix + region] = \
+                    RulesetVsRegion._DomainDsc(
+                        region=prefix + region, ruleset=prefix + region,
+                        is_base=False, is_listable=True,
+                        overwrite_region=region)
+            if idx == 0:
+                cls._by_region["DEFAULT"] = \
+                    RulesetVsRegion._DomainDsc(
+                        region="DEFAULT", ruleset=ruleset,
+                        is_base=False, is_listable=False,
+                        overwrite_region=None)
+
+
+class SpecialCertifications:
+    """ Special Certificate/serial names.
+    Better be explicitly disabled in production database """
+    _Key = NamedTuple("_Key", [("cert_id", str), ("serial_number", str)])
+    Properties = NamedTuple("Properties", [("location_flags", int)])
+
+    # Certificate dictionary. Initialized on first call to class methods
+    _special_certificates: Dict["SpecialCertifications._Key",
+                              "SpecialCertifications.Properties"] = {}
+
+    @classmethod
+    def get_properties(cls, cert_id: str, serial_number: str) \
+            -> Optional["SpecialCertifications.Properties"]:
+        cls._initialize()
+        return \
+            cls._special_certificates.get(
+                cls._Key(cert_id=cert_id, serial_number=serial_number))
+
+    @classmethod
+    def _initialize(cls) -> None:
+        if cls._special_certificates:
+            return
+        for cert_id, serial_number, location_flags in \
+               [("TestCertificationId", "TestSerialNumber",
+                 aaa.CertId.OUTDOOR | aaa.CertId.INDOOR),
+                ("HeatMapCertificationId", "HeatMapSerialNumber",
+                 aaa.CertId.OUTDOOR | aaa.CertId.INDOOR)]:
+            key = cls._Key(cert_id=cert_id, serial_number=serial_number)
+            assert key not in cls._special_certificates
+            cls._special_certificates[key] = \
+                cls.Properties(location_flags=location_flags)
+
+
+class VendorExtensionFilter:
+    """ Filters Vendor Extensions from Messages and requests/responses
+    according to type-specific whitelists """
+    class _WhitelistType(NamedTuple):
+        """ Whitelist type """
+        # True for message, False for request/response, None for both
+        is_message: Optional[bool] = None
+        # True for input (request), false for output(response), None for both
+        is_input: Optional[bool] = None
+        # True for GUI, False for non-GUI, None for both
+        is_gui: Optional[bool] = None
+        # True for internal, False for external, None for both
+        is_internal: Optional[bool] = None
+
+        def is_partial(self):
+            """ True for partial whitelist type that has fields set to None """
+            return any(getattr(self, attr) is None for attr in self._fields)
+
+    class _Whitelist:
+        """ Whitelist for a message/request/response type(s)
+
+        Public attributes:
+        extensions -- Set of allowed extension IDs
+
+        Private attributes
+        _partial_type -- Specifies type(s) of messages/resuests/response this
+                          whitelist is for
+        """
+
+        def __init__(self, extensions: List[str],
+                     partial_type: "VendorExtensionFilter._WhitelistType") \
+                -> None:
+            """ Constructor
+
+            Arguments:
+            extensions   -- List of whitelisted extension names
+            partial_type -- Type(s) of messages/resuests/response this
+                             whitelist is for
+            """
+            assert isinstance(extensions, list)
+            self._partial_type = partial_type
+            self.extensions = set(extensions)
+
+        def is_for(
+                self,
+                whitelist_type: "VendorExtensionFilter._WhitelistType") \
+                -> bool:
+            """ True if this whilelist is for messages/requests/responses
+            specified by nonpartial whitelist type """
+            assert not whitelist_type.is_partial()
+            for attr in whitelist_type._fields:
+                value = getattr(whitelist_type, attr)
+                if getattr(self._partial_type, attr) not in (None, value):
+                    return False
+            return True
+
+    # List of whilelists. Only nonempty whitelists are presented
+    # It is OK for more than one whitelist to cover some type
+    # It is OK to add more whitelists (e.g. for different whitelist types)
+    _whitelists = [
+        # Allowed vendor extensions for individual requests from AFC services
+        # (NOT from APs)
+        _Whitelist(
+            ["openAfc.overrideAfcConfig"],
+            _WhitelistType(is_input=True, is_message=False, is_internal=True)),
+        # Allowed vendor extensions for individual requests received from APs
+        _Whitelist(
+            ["rlanAntenna"],
+            _WhitelistType(is_input=True, is_message=False)),
+        # Allowed vendor extensions for individual responses sent to AFC Web
+        # GUI
+        _Whitelist(
+            ["openAfc.redBlackData", "openAfc.mapinfo"],
+            _WhitelistType(is_input=False, is_message=False, is_gui=True)),
+        _Whitelist(
+            ["openAfc.heatMap"],
+            _WhitelistType(is_input=True, is_gui=True))]
+
+    # Dictionary of allowed extensions, indexed by nonpartial whitelist types
+    # Filled on first call of member function
+    _whitelist_dict: Dict["VendorExtensionFilter._WhitelistType",
+                          Set[str]] = {}
+
+    @classmethod
+    def allowed_extension(cls, extension: str, is_message: bool,
+                          is_input: bool, is_gui: bool, is_internal: bool) \
+            -> bool:
+        """ True if given vendor extension is allowed for given message type
+
+        Arguments:
+        extension   -- Extension ID in question
+        is_message  -- True for message, false for individual request/response
+        is_input    -- True for request, False for response
+        is_gui      -- True if from GUI
+        is_internal -- True if internal (from within AFC Cluster)
+        """
+        cls._initialize()
+        return \
+            extension in \
+            cls._whitelist_dict.get(
+                cls._WhitelistType(
+                    is_message=is_message, is_input=is_input,
+                    is_gui=is_gui, is_internal=is_internal),
+                set())
+
+    @classmethod
+    def _initialize(cls):
+        """ One-time initialization """
+        if cls._whitelist_dict:
+            return
+        # Maps whitelist types to sets of allowed extensions
+        for is_message in (True, False):
+            for is_input in (True, False):
+                for is_gui in (True, False):
+                    for is_internal in (True, False):
+                        whitelist_type = \
+                            cls._WhitelistType(
+                                is_input=is_input, is_message=is_message,
+                                is_gui=is_gui, is_internal=is_internal)
+                        # Ensure that no attributes were omitted
+                        assert not whitelist_type.is_partial()
+                        # Finding whitelist for key
+                        for wl in cls._whitelists:
+                            if wl.is_for(whitelist_type):
+                                cls._whitelist_dict.setdefault(
+                                    whitelist_type, set()).\
+                                    update(wl.extensions)

--- a/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
+++ b/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
@@ -127,7 +127,7 @@ class SpecialCertifications:
 
     # Certificate dictionary. Initialized on first call to class methods
     _special_certificates: Dict["SpecialCertifications._Key",
-                               "SpecialCertifications.Properties"] = {}
+                                "SpecialCertifications.Properties"] = {}
 
     @classmethod
     def get_properties(cls, cert_id: str, serial_number: str) \

--- a/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
+++ b/src/afc-packages/afcmodels/afcmodels/hardcoded_relations.py
@@ -8,7 +8,11 @@
 
 from typing import Dict, List, NamedTuple, Optional, Set
 
-from . import aaa
+
+# Bits in 'location' field of cart_id table (represented by aaa.CertId)
+CERT_ID_LOCATION_UNKNOWN = 0
+CERT_ID_LOCATION_OUTDOOR = 2
+CERT_ID_LOCATION_INDOOR = 1
 
 
 class RulesetVsRegion:
@@ -143,9 +147,9 @@ class SpecialCertifications:
             return
         for cert_id, serial_number, location_flags in \
                 [("TestCertificationId", "TestSerialNumber",
-                  aaa.CertId.OUTDOOR | aaa.CertId.INDOOR),
+                  CERT_ID_LOCATION_OUTDOOR | CERT_ID_LOCATION_INDOOR),
                  ("HeatMapCertificationId", "HeatMapSerialNumber",
-                  aaa.CertId.OUTDOOR | aaa.CertId.INDOOR)]:
+                  CERT_ID_LOCATION_OUTDOOR | CERT_ID_LOCATION_INDOOR)]:
             key = cls._Key(cert_id=cert_id, serial_number=serial_number)
             assert key not in cls._special_certificates
             cls._special_certificates[key] = \

--- a/src/afc-packages/rcache/rcache_req_cfg_hash.py
+++ b/src/afc-packages/rcache/rcache_req_cfg_hash.py
@@ -1,0 +1,41 @@
+""" Computes request/config hash and other collaterals """
+#
+# Copyright (C) 2023 Broadcom. All rights reserved. The term "Broadcom"
+# refers solely to the Broadcom Inc. corporate affiliate that owns
+# the software below. This work is licensed under the OpenAFC Project License,
+# a copy of which is included with this software program
+#
+# pylint: disable=too-few-public-methods
+
+import hashlib
+import json
+from typing import Any, Dict
+
+
+class RequestConfigHash:
+    """ Computes and holds request/config hash and other collaterals
+
+    Public attributes:
+    req_cfg_hash -- Request/config hash
+    cfg_str      -- AFC Config as string
+    cfg_hash     -- Config hash (None if not requested)
+    """
+    def __init__(self, req_dict: Dict[str, Any],
+                 afc_config_dict: Dict[str, Any],
+                 compute_config_hash: bool = False) -> None:
+        """ Constructor
+
+        Arguments:
+        req_dict            -- Individual AFC Request in dictionary form
+        afc_config_dict     -- AFC Config in dictionary form
+        compute_config_hash -- True to also compute config hash
+        """
+        md5 = hashlib.md5()
+        self.cfg_str = json.dumps(afc_config_dict, sort_keys=True)
+        md5.update(self.cfg_str.encode("utf-8"))
+        self.cfg_hash = md5.hexdigest() if compute_config_hash else None
+        md5.update(
+            json.dumps(
+                {k: v for k, v in req_dict.items() if k != "requestId"},
+                sort_keys=True).encode('utf-8'))
+        self.req_cfg_hash = md5.hexdigest()

--- a/src/afc-packages/rcache/setup.py
+++ b/src/afc-packages/rcache/setup.py
@@ -19,7 +19,7 @@ setup(
     version='0.1.0',
     description='AFC packages',
     py_modules=["rcache_client", "rcache_common", "rcache_db", "rcache_models",
-                "rcache_rcache", "rcache_rmq"],
+                "rcache_req_cfg_hash", "rcache_rcache", "rcache_rmq"],
     cmdclass={
         'install': InstallCmdWrapper,
     }

--- a/src/ratapi/ratapi/manage.py
+++ b/src/ratapi/ratapi/manage.py
@@ -983,9 +983,8 @@ class CertIdSweep(Command):
                                 cert = CertId(certification_id=fcc_id,
                                               location=CertId.OUTDOOR)
                                 ruleset_id_str = \
-                                        RulesetVsRegion.region_to_ruleset(
-                                            "US",
-                                            exc=werkzeug.exceptions.NotFound)
+                                    RulesetVsRegion.region_to_ruleset(
+                                        "US", exc=werkzeug.exceptions.NotFound)
                                 ruleset = Ruleset.query.filter_by(
                                     name=ruleset_id_str).first()
                                 ruleset.cert_ids.append(cert)

--- a/src/ratapi/ratapi/views/admin.py
+++ b/src/ratapi/ratapi/views/admin.py
@@ -22,9 +22,9 @@ from werkzeug import exceptions
 from sqlalchemy.exc import IntegrityError
 import werkzeug
 import afcmodels.aaa as aaa
+from afcmodels.hardcoded_relations import RulesetVsRegion
 from .auth import auth
 from afcmodels.base import db
-from .ratapi import rulesetIdToRegionStr, rulesets
 
 #: Logger for this module
 LOGGER = logging.getLogger(__name__)
@@ -209,7 +209,7 @@ class AccessPointDeny(MethodView):
                 access_points = organization.aps
 
         # translate ruleset.id to index into rulesets
-        rules = rulesets()
+        rules = RulesetVsRegion.ruleset_list()
         rule_map = {}
         for idx, rule in enumerate(rules):
             r = db.session.query(aaa.Ruleset).filter(
@@ -218,7 +218,7 @@ class AccessPointDeny(MethodView):
                 rule_map[r.id] = idx
 
         return flask.jsonify(
-            rulesets=rules,
+            rulesets=RulesetVsRegion.ruleset_list(),
             access_points={
                 "data": [
                     "{},{},{},{}".format(

--- a/src/ratapi/ratapi/views/ratafc.py
+++ b/src/ratapi/ratapi/views/ratafc.py
@@ -23,7 +23,6 @@ import glob
 import re
 import datetime
 import zlib
-import hashlib
 import uuid
 import copy
 import platform
@@ -42,8 +41,10 @@ from afc_worker import run
 from ..util import AFCEngineException, require_default_uls, getQueueDirectory
 from afcmodels.aaa import User, AFCConfig, CertId, Ruleset, \
     Organization, AccessPointDeny
+from afcmodels.hardcoded_relations import RulesetVsRegion, \
+    SpecialCertifications, VendorExtensionFilter
 from .auth import auth
-from .ratapi import build_task, rulesetIdToRegionStr
+from .ratapi import build_task
 from fst import DataIf
 import afctask
 import als
@@ -52,10 +53,10 @@ from flask_login import current_user
 from .auth import auth
 import traceback
 from urllib.parse import urlparse
-from .ratapi import rulesets
 from typing import Any, Dict, NamedTuple, Optional
 from rcache_models import RcacheClientSettings
 from rcache_client import RcacheClient
+from rcache_req_cfg_hash import RequestConfigHash
 import prometheus_client
 
 LOGGER = logging.getLogger(__name__)
@@ -71,7 +72,7 @@ prometheus_metric_flask_afc_waiting_reqs = \
 
 # We want to dynamically trim this this list e.g.
 # via environment variable, for the current deployment
-RULESETS = rulesets()
+RULESETS = RulesetVsRegion.ruleset_list()
 
 #: All views under this API blueprint
 module = flask.Blueprint('ap-afc', 'ap-afc')
@@ -220,163 +221,33 @@ def _translate_afc_error(error_msg):
         raise VersionNotSupportedException()
 
 
-class VendorExtensionFilter:
-    """ Filters Vendor Extensions from Messages and requests/responses
-    according to type-specific whitelists
+def drop_unwanted_extensions(json_dict, is_input, is_gui, is_internal):
+    """ Removes unallowed vendor extensions from given message
 
-    Private attributes:
-    _whitelist_dict -- Dictionary of whitelists, indexed by (nonpartial)
-                       whitelist types
+    Arguments:
+    json_dict   -- AFC Request/Response message in dictionary form
+    is_input    -- True for request, False for response
+    is_gui      -- True if from GUI
+    is_internal -- True if internal (from within AFC Cluster)
     """
-    class _WhitelistType(NamedTuple):
-        """ Whitelist type """
-        # True for message, False for request/response, None for both
-        is_message: Optional[bool] = None
-        # True for input (request), false for output(response), None for both
-        is_input: Optional[bool] = None
-        # True for GUI, False for non-GUI, None for both
-        is_gui: Optional[bool] = None
-        # True for internal, False for external, None for both
-        is_internal: Optional[bool] = None
-
-        def is_partial(self):
-            """ True for partial whitelist type that has fields set to None """
-            return any(getattr(self, attr) is None for attr in self._fields)
-
-    class _Whitelist:
-        """ Whitelist for a message/request/response type(s)
-
-        Public attributes:
-        extensions -- Set of allowed extension IDs
-
-        Private attributes
-        _partial_type -- Specifies type(s) of messages/resuests/response this
-                          whitelist is for
-        """
-
-        def __init__(self, extensions, partial_type):
-            """ Constructor
-
-            Arguments:
-            extensions   -- Sequence of whitelisted extensions
-            partial_type -- Type(s) of messages/resuests/response this
-                             whitelist is for
-            """
-            assert isinstance(extensions, list)
-            self._partial_type = partial_type
-            self.extensions = set(extensions)
-
-        def is_for(self, whitelist_type):
-            """ True if this whilelist is for messages/requests/responses
-            specified by nonpartial whitelist type """
-            assert not whitelist_type.is_partial()
-            for attr in whitelist_type._fields:
-                value = getattr(whitelist_type, attr)
-                if getattr(self._partial_type, attr) not in (None, value):
-                    return False
-            return True
-
-    # List of whilelists. Only nonempty whitelists are presented
-    # It is OK for more than one whitelist to cover some type
-    # It is OK to add more whitelists (e.g. for different whitelist types)
-    _whitelists = [
-        # Allowed vendor extensions for individual requests from AFC services
-        # (NOT from APs)
-        _Whitelist(
-            ["openAfc.overrideAfcConfig"],
-            _WhitelistType(is_input=True, is_message=False, is_internal=True)),
-        # Allowed vendor extensions for individual requests received from APs
-        _Whitelist(
-            ["rlanAntenna"],
-            _WhitelistType(is_input=True, is_message=False)),
-        # Allowed vendor extensions for individual responses sent to AFC Web
-        # GUI
-        _Whitelist(
-            ["openAfc.redBlackData", "openAfc.mapinfo"],
-            _WhitelistType(is_input=False, is_message=False, is_gui=True)),
-        _Whitelist(
-            ["openAfc.heatMap"],
-            _WhitelistType(is_input=True, is_gui=True))]
-
-    def __init__(self):
-        """ Constructor """
-        # Maps whitelist types to sets of allowed extensions
-        self._whitelist_dict = {}
-        for is_message in (True, False):
-            for is_input in (True, False):
-                for is_gui in (True, False):
-                    for is_internal in (True, False):
-                        whitelist_type = \
-                            self._WhitelistType(
-                                is_input=is_input, is_message=is_message,
-                                is_gui=is_gui, is_internal=is_internal)
-                        # Ensure that no attributes were omitted
-                        assert not whitelist_type.is_partial()
-                        # Finding whitelist for key
-                        for wl in self._whitelists:
-                            if wl.is_for(whitelist_type):
-                                self._whitelist_dict.setdefault(
-                                    whitelist_type, set()).\
-                                    update(wl.extensions)
-
-    def filter(self, json_dict, is_input, is_gui, is_internal):
-        """ Filtering out nonwhitelisted vendor extensions
-
-        Arguments:
-        json_dict   -- Dictionary made of message
-        is_input    -- True for input (request), False for output (Response)
-        is_gui      -- True for GUI
-        is_internal -- True for internal
-        """
-        if not isinstance(json_dict, dict):
-            return
-        # First filtering message
-        self._filter_ext_list(
-            json_dict,
-            self._WhitelistType(is_message=True, is_input=is_input,
-                                is_gui=is_gui, is_internal=is_internal))
-        # Filtering individual requests/responses
-        for req_resp in \
-                json_dict.get("availableSpectrumInquiryRequests" if is_input
-                              else "availableSpectrumInquiryResponses", []):
-            self._filter_ext_list(
-                req_resp,
-                self._WhitelistType(is_message=False, is_input=is_input,
-                                    is_gui=is_gui, is_internal=is_internal))
-
-    def _filter_ext_list(self, container, whitelist_type):
-        """ Drops extensions that not passed whitelist
-
-        Arguments:
-        container      -- Dictionary that (may) contain "vendorExtensions"
-                          list. Modified inplace
-        whitelist_type -- Type of whitelist to apply
-        """
-        if not isinstance(container, dict):
-            return
+    for container, is_message in [(json_dict, True)] + \
+            [(req_resp, False) for req_resp in
+             json_dict.get("availableSpectrumInquiryRequests" if is_input
+                           else "availableSpectrumInquiryResponses", [])]:
         extensions = container.get("vendorExtensions")
         if extensions is None:
-            return
-        assert not whitelist_type.is_partial()
-        allowed_extensions = self._whitelist_dict.get(whitelist_type)
-        if not allowed_extensions:
-            del container["vendorExtensions"]
-            return
+            continue
         idx = 0
         while idx < len(extensions):
-            if extensions[idx]["extensionId"] not in allowed_extensions:
-                extensions.pop(idx)
-            else:
+            if VendorExtensionFilter.allowed_extension(
+                    extension=extensions[idx]["extensionId"],
+                    is_message=is_message, is_input=is_input, is_gui=is_gui,
+                    is_internal=is_internal):
                 idx += 1
+            else:
+                extensions.pop(idx)
         if not extensions:
             del container["vendorExtensions"]
-
-
-def get_vendor_extension_filter():
-    """ Returns VendorExtensionFilter instance for given app instance"""
-    if not hasattr(flask.g, "vendor_extension_filter"):
-        flask.g.vendor_extension_filter = VendorExtensionFilter()
-    return flask.g.vendor_extension_filter
 
 
 def _get_vendor_extension(json_dict, ext_id):
@@ -482,8 +353,8 @@ def success_done(t):
                         map_data,
                         16 +
                         zlib.MAX_WBITS).decode('iso-8859-1') if map_data else None}})
-    get_vendor_extension_filter().filter(
-        resp_json, is_input=False,
+    drop_unwanted_extensions(
+        json_dict=resp_json, is_input=False,
         is_gui=bool(task_stat['runtime_opts'] & RNTM_OPT_GUI),
         is_internal=bool(task_stat['is_internal_request']))
     resp_data = json.dumps(resp_json)
@@ -604,14 +475,11 @@ class RatAfc(MethodView):
 
             ruleset = prefix
 
-            # Test AP will by pass certification ID check as Indoor Certified
-            if cert_id == "TestCertificationId" \
-               and serial_number == "TestSerialNumber":
-                return True
-
-            if cert_id == "HeatMapCertificationId" \
-               and serial_number == "HeatMapSerialNumber":
-                return True
+            scp = \
+                SpecialCertifications.get_properties(
+                    cert_id=cert_id, serial_number=serial_number)
+            if scp is not None:
+                return (scp.location_flags & CertId.INDOOR) != 0
 
             # Assume that once we got here, we already trim the cert_obj list
             # down to only one entry for the country we're operating in
@@ -662,7 +530,7 @@ class RatAfc(MethodView):
             is_internal_request = urlparse(flask.request.url).path.\
                 endswith("/availableSpectrumInquiryInternal")
             is_gui = flask.request.args.get('gui') == 'True'
-            get_vendor_extension_filter().filter(
+            drop_unwanted_extensions(
                 json_dict=flask.request.json, is_input=True, is_gui=is_gui,
                 is_internal=is_internal_request)
             # start request
@@ -726,7 +594,9 @@ class RatAfc(MethodView):
                             # empty/non-exist ruleset
                             break
                         if prefix in RULESETS:
-                            region = rulesetIdToRegionStr(prefix)
+                            region = \
+                                RulesetVsRegion.ruleset_to_region(
+                                    prefix, exc=werkzeug.exceptions.NotFound)
                             certId = r.get('id')
                             break
                         prefix = prefix.strip()
@@ -789,40 +659,35 @@ class RatAfc(MethodView):
                             AFCConfig.config['regionStr'].astext == region).first()
                     if not config:
                         raise DeviceUnallowedException(
-                            "No AFC configuration for ruleset")
+                            "No AFC configuration for ruleset " + str(region))
                     afc_config = config.config
-                    if region[:5] == "TEST_" or region[:5] == 'DEMO_':
-                        afc_config = dict(afc_config)
-                        afc_config['regionStr'] = region[5:]
-                    config_str = json.dumps(afc_config, sort_keys=True)
+                    try:
+                        overwrite_region = \
+                            RulesetVsRegion.overwrite_region(
+                                region, exc=KeyError)
+                        if overwrite_region:
+                            afc_config = dict(afc_config)
+                            afc_config['regionStr'] = overwrite_region
+                    except KeyError:
+                        pass
 
-                    # calculate hash of config
-                    hashlibobj = hashlib.md5()
-                    hashlibobj.update(config_str.encode('utf-8'))
-                    config_hash = hashlibobj.hexdigest()
+                    rcc = RequestConfigHash(req_dict=individual_request,
+                                            afc_config_dict=afc_config,
+                                            compute_config_hash=True)
                     config_path = \
-                        os.path.join("/afc_config", prefix, config_hash,
+                        os.path.join("/afc_config", prefix, rcc.cfg_hash,
                                      "afc_config.json") if use_tasks else None
-
-                    # calculate hash of config + request
-                    hashlibobj.update(
-                        json.dumps(
-                            {k: v for k, v in individual_request.items()
-                             if k != "requestId"},
-                            sort_keys=True).encode('utf-8'))
-                    req_cfg_hash = hashlibobj.hexdigest()
-
                     history_dir = None
                     if runtime_opts & (RNTM_OPT_DBG | RNTM_OPT_SLOW_DBG):
                         history_dir =\
                             os.path.join(
                                 "/history", str(serial),
                                 str(datetime.datetime.now().isoformat()))
-                    req_infos[req_cfg_hash] = \
+                    req_infos[rcc.req_cfg_hash] = \
                         ReqInfo(
-                            req_idx=req_idx, req_cfg_hash=req_cfg_hash,
+                            req_idx=req_idx, req_cfg_hash=rcc.req_cfg_hash,
                             request_id=individual_request["requestId"],
-                            request=request, config_str=config_str,
+                            request=request, config_str=rcc.cfg_str,
                             config_path=config_path, region=region,
                             history_dir=history_dir, request_type=request_type,
                             runtime_opts=runtime_opts,
@@ -883,8 +748,8 @@ class RatAfc(MethodView):
                     engine_result_ext = \
                         _get_vendor_extension(actualResult[0],
                                               "openAfc.used_data") or {}
-                    uls_id = engine_result_ext.get("openAfc.uls_id", uls_id)
-                    geo_id = engine_result_ext.get("openAfc.geo_id", geo_id)
+                    uls_id = engine_result_ext.get("uls_id", uls_id)
+                    geo_id = engine_result_ext.get("geo_id", geo_id)
                     actualResult[0]["requestId"] = req_info.request_id
                     results["availableSpectrumInquiryResponses"].append(
                         actualResult[0])
@@ -924,7 +789,7 @@ class RatAfc(MethodView):
                  "response": response_info})
 
         # Removing internal vendor extensions
-        get_vendor_extension_filter().filter(
+        drop_unwanted_extensions(
             json_dict=results, is_input=False, is_gui=is_gui,
             is_internal=is_internal_request)
 

--- a/src/ratapi/ratapi/views/ratafc.py
+++ b/src/ratapi/ratapi/views/ratafc.py
@@ -42,7 +42,8 @@ from ..util import AFCEngineException, require_default_uls, getQueueDirectory
 from afcmodels.aaa import User, AFCConfig, CertId, Ruleset, \
     Organization, AccessPointDeny
 from afcmodels.hardcoded_relations import RulesetVsRegion, \
-    SpecialCertifications, VendorExtensionFilter
+    SpecialCertifications, VendorExtensionFilter, CERT_ID_LOCATION_UNKNOWN, \
+    CERT_ID_LOCATION_OUTDOOR, CERT_ID_LOCATION_INDOOR
 from .auth import auth
 from .ratapi import build_task
 from fst import DataIf
@@ -442,9 +443,9 @@ class RatAfc(MethodView):
                          self.__class__, inspect.stack()[0][3],
                          certId.certification_id)
 
-        if not certId.location & certId.OUTDOOR:
+        if not certId.location & CERT_ID_LOCATION_OUTDOOR:
             raise DeviceUnallowedException("Outdoor operation not allowed")
-        elif certId.location & certId.INDOOR:
+        elif certId.location & CERT_ID_LOCATION_INDOOR:
             indoor_certified = True
         else:
             indoor_certified = False


### PR DESCRIPTION
- afc-packages/afmodels/afcmodels/hardcoded_relations.py introduced. It contains following hardcoded (DB-worthy) stuff from ratafc/ratapi:
  - RulesetVsRegion class that encapsulates conversion between regionStr of AFC Config and Ruleset IDs of AFC requests/responses
  - SpecialCertifications class that encapsulates properties of special certification IDs and serial numbers
  - VendorExtensionFilter class that encapsulates whitelists of Vendor Extensions, used in AFC requests/responses
- afc-packages/rcache/rcache_req_cfg_hash.py introduced that encapsulates computation of request/config hash (key in Rcache database)
- Corresponded code removed from ratapo.py and ratafc.py
- Mentioned above classes applied in manage.py, admin.py. ratapi.py, ratafc.py

Regression tests passed, cached load test seemingly works fine