### PR TITLE
122. Adding afcserver and sme improvements into helm/

### DIFF
--- a/helm/afc-int/templates/deployment-afcserver.yaml
+++ b/helm/afc-int/templates/deployment-afcserver.yaml
@@ -7,6 +7,7 @@
 # Deployment helmchart for afcserver pods
 
 {{- $ := mergeOverwrite $ (dict "component" "afcserver") }}
+{{- if (include "afc.fullImageName" .) }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -34,3 +35,5 @@ spec:
           volumeMounts: {{- include "afc.staticVolumeMounts" . | nindent 12 }}
       volumes:
         {{- include "afc.staticVolumes" . | nindent 8 }}
+
+{{- end -}}

--- a/helm/afc-int/templates/deployment-afcserver.yaml
+++ b/helm/afc-int/templates/deployment-afcserver.yaml
@@ -1,0 +1,36 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Deployment helmchart for afcserver pods
+
+{{- $ := mergeOverwrite $ (dict "component" "afcserver") }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "afc.compManifestName" . }}
+  labels: {{- include "afc.commonLabels" . | nindent 4 }}
+  annotations: {{- include "afc.commonDeploymentAnnotations" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "afc.selectorLabels" . | nindent 6 }}
+  replicas: {{ include "afc.replicas" . }}
+  {{- include "afc.serviceAccountRef" . | indent 2 }}
+  {{- include "afc.securityContext" . | indent 2 }}
+  template:
+    metadata:
+      labels: {{- include "afc.commonLabels" . | nindent 8 }}
+    spec:
+      {{- include "afc.imagePullSecrets" . | indent 6 }}
+      containers:
+        - {{- include "afc.containerImage" . | nindent 10 }}
+          {{- include "afc.probes" . | nindent 10 }}
+          env: {{- include "afc.env" . | nindent 12 }}
+          ports: {{- include "afc.containerPorts" . | nindent 12 }}
+          resources: {{- include "afc.containerResources" . | nindent 12 }}
+          volumeMounts: {{- include "afc.staticVolumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "afc.staticVolumes" . | nindent 8 }}

--- a/helm/afc-int/templates/deployment-msghnd.yaml
+++ b/helm/afc-int/templates/deployment-msghnd.yaml
@@ -7,6 +7,7 @@
 # Deployment helmchart for msghnd pods
 
 {{- $ := mergeOverwrite $ (dict "component" "msghnd") }}
+{{- if (include "afc.fullImageName" .) }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -34,3 +35,5 @@ spec:
           volumeMounts: {{- include "afc.staticVolumeMounts" . | nindent 12 }}
       volumes:
         {{- include "afc.staticVolumes" . | nindent 8 }}
+
+{{- end -}}

--- a/helm/afc-int/templates/hpa-afcserver.yaml
+++ b/helm/afc-int/templates/hpa-afcserver.yaml
@@ -1,0 +1,27 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Worker autoscaler on number of processed requests
+
+{{- $ := mergeOverwrite $ (dict "component" "afcserver") }}
+{{- $compDef := merge (dict) (get $.Values.components .component | required (cat "No component for this component key:" .component)) $.Values.components.default -}}
+{{- if and (hasKey $compDef "hpa") (include "afc.fullImageName" .) }}
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "afc.compManifestName" . }}
+  labels: {{- include "afc.commonLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "afc.compManifestName" . }}
+  {{- include "afc.hpaReplicas" . | nindent 2 }}
+  {{- include "afc.hpaBehavior" . | nindent 2 }}
+  metrics: {{- include "afc.hpaMetric" . | nindent 4 }}
+
+{{- end -}}

--- a/helm/afc-int/templates/hpa-worker.yaml
+++ b/helm/afc-int/templates/hpa-worker.yaml
@@ -7,6 +7,8 @@
 # Worker autoscaler on number of processed requests
 
 {{- $ := mergeOverwrite $ (dict "component" "worker") }}
+{{- $compDef := merge (dict) (get $.Values.components .component | required (cat "No component for this component key:" .component)) $.Values.components.default -}}
+{{- if hasKey $compDef "hpa" }}
 
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -21,3 +23,5 @@ spec:
   {{- include "afc.hpaReplicas" . | nindent 2 }}
   {{- include "afc.hpaBehavior" . | nindent 2 }}
   metrics: {{- include "afc.hpaMetric" . | nindent 4 }}
+
+{{- end -}}

--- a/helm/afc-int/templates/ingress-afcserver.yaml
+++ b/helm/afc-int/templates/ingress-afcserver.yaml
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Ingress for afcserver endpoints
+
+{{- $ := mergeOverwrite $ (dict "component" "afcserver") }}
+{{- $compDef := merge (dict) (get $.Values.components .component | required (cat "No component for this component key:" .component)) $.Values.components.default -}}
+{{- $ingressDef := default (dict) (get $compDef "ingress") -}}
+{{- if and ($ingressDef) (get $ingressDef "rules") (not (get $compDef "noIngress")) (include "afc.fullImageName" .) }}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "afc.compManifestName" . }}
+  labels: {{- include "afc.commonLabels" . | nindent 4 }}
+  annotations: {{- include "afc.ingressAnnotations" . | nindent 4 }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths: {{- include "afc.ingressPaths" . | nindent 10 }}
+
+{{- end -}}

--- a/helm/afc-int/templates/podmonitor-msghnd.yaml
+++ b/helm/afc-int/templates/podmonitor-msghnd.yaml
@@ -7,7 +7,7 @@
 # Prometheus operator Pod Monitor for msghnd
 {{- $ := mergeOverwrite $ (dict "component" "msghnd") }}
 {{- $compDef := merge (dict) (get $.Values.components .component | required (cat "No component for this component key:" .component)) $.Values.components.default -}}
-{{- if hasKey $compDef "metrics"}}
+{{- if and (hasKey $compDef "metrics") (include "afc.fullImageName" .) }}
 
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/helm/afc-int/templates/service-afcserver.yaml
+++ b/helm/afc-int/templates/service-afcserver.yaml
@@ -1,0 +1,19 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Service helmchart for afcservice pods
+{{- $ := mergeOverwrite $ (dict "component" "afcserver") }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "afc.hostName" . }}
+  labels: {{- include "afc.commonLabels" . | nindent 4 }}
+  {{- include "afc.serviceAnnotations" . | nindent 2 }}
+spec:
+  {{- include "afc.serviceIp" . | nindent 2 }}
+  selector: {{- include "afc.serviceSelector" . | nindent 4 }}
+  ports: {{- include "afc.servicePorts" . | nindent 4 }}

--- a/helm/afc-int/templates/service-afcserver.yaml
+++ b/helm/afc-int/templates/service-afcserver.yaml
@@ -6,6 +6,7 @@
 
 # Service helmchart for afcservice pods
 {{- $ := mergeOverwrite $ (dict "component" "afcserver") }}
+{{- if (include "afc.fullImageName" .) }}
 
 apiVersion: v1
 kind: Service
@@ -17,3 +18,5 @@ spec:
   {{- include "afc.serviceIp" . | nindent 2 }}
   selector: {{- include "afc.serviceSelector" . | nindent 4 }}
   ports: {{- include "afc.servicePorts" . | nindent 4 }}
+
+{{- end -}}

--- a/helm/afc-int/templates/service-msghnd.yaml
+++ b/helm/afc-int/templates/service-msghnd.yaml
@@ -6,6 +6,7 @@
 
 # Service helmchart for msghnd pods
 {{- $ := mergeOverwrite $ (dict "component" "msghnd") }}
+{{- if (include "afc.fullImageName" .) }}
 
 apiVersion: v1
 kind: Service
@@ -17,3 +18,5 @@ spec:
   {{- include "afc.serviceIp" . | nindent 2 }}
   selector: {{- include "afc.serviceSelector" . | nindent 4 }}
   ports: {{- include "afc.servicePorts" . | nindent 4 }}
+
+{{- end -}}

--- a/helm/afc-int/values-msghnd.yaml
+++ b/helm/afc-int/values-msghnd.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Parameter values for using msghnd (instead of afcserver) to handle AFC
+# requests
+
+sharedEnv:
+  afc-req-service:
+    host: msghnd
+
+components:
+  msghnd:
+   noIngress: False
+  afcserver:
+    imageName: None

--- a/helm/afc-int/values-msghnd.yaml
+++ b/helm/afc-int/values-msghnd.yaml
@@ -16,4 +16,4 @@ components:
     imageName: afc-msghnd  
     noIngress: False
   afcserver:
-    imageName: None
+    imageName: null

--- a/helm/afc-int/values-msghnd.yaml
+++ b/helm/afc-int/values-msghnd.yaml
@@ -13,6 +13,7 @@ sharedEnv:
 
 components:
   msghnd:
-   noIngress: False
+    imageName: afc-msghnd  
+    noIngress: False
   afcserver:
     imageName: None

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -47,7 +47,8 @@ securityContexts:
   readOnly:
     readOnlyRootFilesystem: true
 
-# Dictionary of environment variable grooups, used by several components.
+# Dictionary of environment variable grooups, used by several components or
+# referred to from other environment variables.
 # Values are dictionaries.
 # Some syntax conventions introduced to properly render values without helm
 # trickery or literal repetitions:
@@ -83,6 +84,12 @@ securityContexts:
 #    in another shared environment block. <IFABSENT> describes what to do if
 #    referred value is absent (see above for values)
 sharedEnv:
+  # Who processes AFC Requests?
+  afc-req-service:
+    # Service name: afcserver or msghnd
+    host: afcserver
+    # Service port
+    port: "80"
   # Flask config parameters defined in config/ratapi.conf. Config settings
   # passed via environment variables should be prefixed with FLASK_, passed via
   # filename environment variables should be prefixed wiyth FLASKFILE_
@@ -96,7 +103,7 @@ sharedEnv:
     FLASKFILE_GOOGLE_APIKEY: >-
       {{secretFile:google-apikey:optional}}
     FLASK_USER_EMAIL_SENDER_EMAIL: admin@afc_please_override.com
-    FLASK_AFC_MSGHND_RATAFC_TOUT: 180
+    FLASK_AFC_MSGHND_RATAFC_TOUT: "180"
   # Flask config parameters retrieved by RatApiConfigurator (should be defined
   # in site-specific values.yaml overrides and/or in secrets). Config settings
   # passed via environment variables should be given as is, passed via
@@ -304,8 +311,8 @@ components:
       AFC_SERVER_NAME: _
       AFC_ENFORCE_HTTPS: "True"
       AFC_ENFORCE_MTLS: "False"
-      AFC_MSGHND_NAME: "{{host:msghnd}}"
-      AFC_MSGHND_PORT: "{{port:msghnd:msghnd}}"
+      AFC_MSGHND_NAME: "{{sameAs:afc-req-service:host}}"
+      AFC_MSGHND_PORT: "{{sameAs:afc-req-service:port}}"
       AFC_WEBUI_NAME: "{{host:rat-server}}"
       AFC_WEBUI_PORT: "{{port:rat-server:rat-server}}"
     sharedEnvKeys:
@@ -409,6 +416,7 @@ components:
       - oidc-client-id
       - oidc-client-secret
       - rcache-db-password
+    noIngress: True
     ingress:
       annotations:
         nginx.ingress.kubernetes.io/proxy-read-timeout: "720"
@@ -422,6 +430,48 @@ components:
           portKey: msghnd
         - path: /fbrat/ap-afc/healthy
           portKey: msghnd
+  afcserver:
+    imageName: afcserver-image
+    imageRepositoryKey: private
+    ports:
+      afcserver:
+        servicePort: 80
+        containerPort: 8000
+        nodePort: 30084
+    env:
+      AFC_SERVER_PORT: 8000
+      AFC_SERVER_GUNICORN_WORKERS: 5
+      AFC_SERVER_RATDB_DSN: >-
+        postgresql://postgres:postgres@{{host:ratdb}}:{{port:ratdb:ratdb}}/fbrat
+      AFC_SERVER_RATDB_PASSWORD_FILE: >-
+        {{secretFile:ratdb-password:optional}}
+      AFC_SERVER_REQUEST_TIMEOUT: >-
+        {{sameAs:flask-conf:FLASK_AFC_MSGHND_RATAFC_TOUT}}
+      AFC_SERVER_CONFIG_REFRESH: 5
+      ALS_KAFKA_SERVER_ID: afcserver
+    sharedEnvKeys:
+      - rcache-common
+      - rcache-client
+      - celery-client
+      - objst-client
+      - objst-common
+      - als-client
+    mountedSecrets:
+      - ratdb-password
+      - rcache-db-password
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "720"
+        nginx.ingress.kubernetes.io/proxy-connect-timeout: "720"
+        nginx.ingress.kubernetes.io/client-body-timeout: "720"
+        nginx.ingress.kubernetes.io/client-header-timeout: "720"
+        nginx.ingress.kubernetes.io/upstream-keepalive-timeout: "720"
+        nginx.ingress.kubernetes.io/keep-alive: "720"
+      rules:
+        - path: /fbrat/ap-afc/availableSpectrumInquiry
+          portKey: afcserver
+        - path: /fbrat/ap-afc/healthy
+          portKey: afcserver
   objst:
     imageName: objstorage-image
     imageRepositoryKey: public
@@ -472,6 +522,7 @@ components:
       AFC_AEP_DEBUG: 1
       AFC_AEP_REAL_MOUNTPOINT: >-
         {{staticVolumeMount:worker:rat_transfer}}/3dep/1_arcsec
+      ALS_KAFKA_SERVER_ID: worker
     sharedEnvKeys:
       - celery-client
       - objst-client
@@ -577,7 +628,7 @@ components:
     imageRepositoryKey: public
     env:
       ULS_AFC_URL: >-
-        http://{{host:msghnd}}:{{port:msghnd:msghnd}}/fbrat/ap-afc/availableSpectrumInquiryInternal?nocache=True
+        http://{{sameAs:afc-req-service:host}}:{{sameAs:afc-req-service:port}}/fbrat/ap-afc/availableSpectrumInquiryInternal?nocache=True
       ULS_DELAY_HR: 0
       ULS_SERVICE_STATE_DB_DSN: >-
         postgresql://postgres:postgres@{{host:bulk-postgres}}/fs_state
@@ -612,6 +663,8 @@ components:
   cert-db:
     imageName: cert_db
     imageRepositoryKey: public
+    env:
+      ALS_KAFKA_SERVER_ID: cert-db
     sharedEnvKeys:
       - flask-conf
       - ratapi-configurator
@@ -639,11 +692,12 @@ components:
     env:
       RCACHE_CLIENT_PORT: "{{port:rcache:rcache}}"
       RCACHE_AFC_REQ_URL: >-
-        http://{{host:msghnd}}:{{port:msghnd:msghnd}}/fbrat/ap-afc/availableSpectrumInquiry?nocache=True
+        http://{{sameAs:afc-req-service:host}}:{{sameAs:afc-req-service:port}}/fbrat/ap-afc/availableSpectrumInquiry?nocache=True
       RCACHE_RULESETS_URL: >-
         http://{{host:rat-server}}/fbrat/ratapi/v1/GetRulesetIDs
       RCACHE_CONFIG_RETRIEVAL_URL: >-
         http://{{host:rat-server}}/fbrat/ratapi/v1/GetAfcConfigByRulesetID
+      ALS_KAFKA_SERVER_ID: rcache
     sharedEnvKeys:
       - rcache-common
       - als-client

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -381,7 +381,8 @@ components:
         - path: /fbrat
           portKey: rat-server
   msghnd:
-    imageName: afc-msghnd
+     # afc-msghnd when enabled
+    imageName: None
     imageRepositoryKey: private
     ports:
       msghnd:

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -382,7 +382,7 @@ components:
           portKey: rat-server
   msghnd:
      # afc-msghnd when enabled
-    imageName: None
+    imageName: null
     imageRepositoryKey: private
     ports:
       msghnd:
@@ -441,7 +441,6 @@ components:
         nodePort: 30084
     env:
       AFC_SERVER_PORT: 8000
-      AFC_SERVER_GUNICORN_WORKERS: 5
       AFC_SERVER_RATDB_DSN: >-
         postgresql://postgres:postgres@{{host:ratdb}}:{{port:ratdb:ratdb}}/fbrat
       AFC_SERVER_RATDB_PASSWORD_FILE: >-

--- a/helm/bin/helm_install_ext.py
+++ b/helm/bin/helm_install_ext.py
@@ -11,9 +11,9 @@ import os
 import sys
 from typing import List, Optional
 
-from utils import ArgumentParserFromFile, auto_name, AUTO_NAME, execute, \
-    EXT_HELM_REL_DIR, parse_json_output, parse_kubecontext, \
-    print_helm_values, ROOT_DIR, set_silent_execute
+from utils import ArgumentParserFromFile, auto_name, AUTO_NAME, Duration, \
+    execute, EXT_HELM_REL_DIR, parse_json_output, parse_kubecontext, \
+    print_helm_values, ROOT_DIR, set_silent_execute, wait_termination
 
 # values.yaml path to default image tag
 DEFAULT_IMAGE_TAG_PATH = "components.default.imageTag"
@@ -108,6 +108,9 @@ def main(argv: List[str]) -> None:
     # If release currently running and no upgrade - uninstall it first
     if was_running and (args.uninstall or (not args.upgrade)):
         execute(["helm", "uninstall", release] + cluster_context.helm_args())
+        print(">> Waiting for uninstallation completion")
+        wait_termination(what=release, cluster_context=cluster_context,
+                         uninstall_duration=Duration(args.wait))
 
     if args.uninstall:
         return

--- a/helm/bin/install_prerequisites.yaml
+++ b/helm/bin/install_prerequisites.yaml
@@ -25,6 +25,8 @@ default_install_components: []
 #   - postinstall. List of commands to perform after kubernetes/helm
 #             installation. Commands that starts with `-` - not checked for
 #             failure. Executed from checkout root directory
+#   - postuninstall. List of commands to perform after kubernetes/helm
+#             uninstallation
 #   - manifest. Path or URL to manifest file or directory. Path may use ~ and
 #             $. Relative paths are from script's directory'
 #   - manifest_url. URL to manifest file or directory

--- a/helm/bin/utils.py
+++ b/helm/bin/utils.py
@@ -8,6 +8,7 @@
 # pylint: disable=invalid-name, too-many-arguments, global-statement
 
 import argparse
+import datetime
 import fnmatch
 import json
 import os
@@ -16,6 +17,7 @@ import shlex
 import socket
 import subprocess
 import sys
+import time
 from typing import Any, cast, Dict, List, NamedTuple, NoReturn, Optional, \
     Set, Union
 import yaml
@@ -523,3 +525,32 @@ def print_helm_values(helm_args: List[str], print_format: str) -> None:
     else:
         error(f"Internal error: unsupported values output format "
               f"'{print_format}'")
+
+
+def wait_termination(what: str, cluster_context: ClusterContext,
+                     namespace: Optional[str] = None,
+                     uninstall_duration: Duration = Duration(None)) -> None:
+    """ Wait until all 'Terminating' extinguished in given context
+
+    Arguments:
+    what               -- What is being uininstalled (for use in error
+                          messages)
+    cluster_context    -- Cluster context
+    namespace          -- Optional namespace name
+    uninstall_duration -- Maximum duration
+    """
+    start = datetime.datetime.now()
+    time.sleep(1)
+    while "Terminating" in \
+            cast(
+                str,
+                execute(
+                    ["kubectl", "get", "all"] +
+                    cluster_context.kubectl_args(namespace=namespace),
+                    return_output=True)):
+        error_if(
+            uninstall_duration and
+            ((datetime.datetime.now() - start).total_seconds() >
+             cast(float, uninstall_duration.seconds())),
+            f"Uninstall timeout expired for {what}")
+        time.sleep(5)


### PR DESCRIPTION
- values.yaml have got afcserver section and sharedEnv.afc-req-service for switching between afcserver and msghnd
- afcserver's helmcharts (deployment, service, ingress, hpa) added
- values.msghnd.yaml added. It contains values.yaml patches to switch from afcserver to msghnd
- helm_install_int.py have got --msghnd to use msghnd instead of afcserver
- helm_install_*.py now wait for uninstallation completion
- install_prerequesites.yaml have got postuninstall clause in component section (used to strip istio from namespace)
