### PR TITLE
152. 'run ngnx-rat_server-rmq-worker path tests' step added to github regression tests

### DIFF
--- a/.github/workflows/regressions-test-remote.yml
+++ b/.github/workflows/regressions-test-remote.yml
@@ -109,7 +109,7 @@ jobs:
         ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }}
     - name: run ngnx-rat_server-rmq-worker path tests
       run: |
-        ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }} https 8 --webui
+        ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }} https 8 "AFCS.SRS.1,AFCS.URS.1,AFCS.FSP.1,AFCS.IBP.1,AFCS.SIP.1,BRCM.EXT_FSP.1" "--webui"
   # }run tests
 
 # stop dev srvr {

--- a/.github/workflows/regressions-test-remote.yml
+++ b/.github/workflows/regressions-test-remote.yml
@@ -107,7 +107,10 @@ jobs:
     - name: run ngnx-afcserver-rmq-worker path tests
       run: |
         ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }}
-# }run tests
+    - name: run ngnx-rat_server-rmq-worker path tests
+      run: |
+        ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }} https 8 "--webui --testcase_ids AFCS.SRS.1,AFCS.URS.1,AFCS.FSP.1,AFCS.IBP.1,AFCS.SIP.1,BRCM.EXT_FSP.1"
+  # }run tests
 
 # stop dev srvr {
     - name: stop dev srvr

--- a/.github/workflows/regressions-test-remote.yml
+++ b/.github/workflows/regressions-test-remote.yml
@@ -109,7 +109,7 @@ jobs:
         ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }}
     - name: run ngnx-rat_server-rmq-worker path tests
       run: |
-        ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }} https 8 "--webui --testcase_ids AFCS.SRS.1,AFCS.URS.1,AFCS.FSP.1,AFCS.IBP.1,AFCS.SIP.1,BRCM.EXT_FSP.1"
+        ${{ github.workspace }}/${{ env.LREGRD }}/run_tests.sh ${{ github.workspace }} afc-regression-test ${{ secrets.AFC_DEV_SERVER }} ${{ env.TEST_PORT }} https 8 --webui
   # }run tests
 
 # stop dev srvr {


### PR DESCRIPTION
It runs afc_tests.py --webui on some tests to make sure that WebUI backend still functions