### PR TITLE
156. Helm improvements

### DIFF
--- a/helm/afc-int/values-k3d.yaml
+++ b/helm/afc-int/values-k3d.yaml
@@ -33,6 +33,11 @@ staticVolumes:
       # Path better be overridden, type set to bypass creation if overridden
       path: /tmp
       type: DirectoryOrCreate
+  objst-storage:
+    hostPath:
+      # Path better be overridden, type set to bypass creation if overridden
+      path: /opt/afc/databases/storage
+      type: DirectoryOrCreate
 
 externalSecrets:
   image-pull: null

--- a/helm/bin/helm_install_ext.py
+++ b/helm/bin/helm_install_ext.py
@@ -110,7 +110,8 @@ def main(argv: List[str]) -> None:
         execute(["helm", "uninstall", release] + cluster_context.helm_args())
         print(">> Waiting for uninstallation completion")
         wait_termination(what=release, cluster_context=cluster_context,
-                         uninstall_duration=Duration(args.wait))
+                         uninstall_duration=Duration(args.wait),
+                         services=["dispatcher"])
 
     if args.uninstall:
         return

--- a/helm/bin/install_prerequisites.py
+++ b/helm/bin/install_prerequisites.py
@@ -169,7 +169,7 @@ class InstallHandler(abc.ABC):
                 if install_wait else None
             if not self._preinstall_impl():
                 continue
-            for cmd in getattr(self._component, "preinstall", []):
+            for cmd in (getattr(self._component, "preinstall", None) or []):
                 result = execute(cmd.lstrip("-"), fail_on_error=False)
                 if (not result) and (not cmd.startswith("-")):
                     continue
@@ -179,7 +179,7 @@ class InstallHandler(abc.ABC):
                         self._cluster_context.kubectl_args())
             if not self._install_impl():
                 continue
-            for cmd in getattr(self._component, "postinstall", []):
+            for cmd in (getattr(self._component, "postinstall", None) or []):
                 result = execute(cmd.lstrip("-"), fail_on_error=False)
                 if (not result) and (not cmd.startswith("-")):
                     continue
@@ -199,7 +199,7 @@ class InstallHandler(abc.ABC):
                     self._cluster_context.kubectl_args() +
                     self._kubectl_uninstall_wait_args(),
                     fail_on_error=False)
-        for cmd in getattr(self._component, "postuninstall", []):
+        for cmd in (getattr(self._component, "postuninstall", None) or []):
             execute(cmd.lstrip("-"), fail_on_error=False)
 
     def _namespace_exists(self) -> bool:
@@ -375,12 +375,14 @@ class HelmInstallHandler(InstallHandler):
             filter_args("--version",
                         getattr(self._component, "helm_version", None)) + \
             self._cluster_context.helm_args(namespace=self._namespace)
-        for helm_values in getattr(self._component, "helm_values", []):
+        for helm_values in \
+                (getattr(self._component, "helm_values", None) or []):
             helm_args += \
                 ["--values", expand_filename(helm_values, root=SCRIPTS_DIR)]
-        for helm_setting in getattr(self._component, "helm_settings", []):
+        for helm_setting in \
+                (getattr(self._component, "helm_settings", None) or []):
             helm_args += ["--set", helm_setting]
-        helm_args += getattr(self._component, "args", []) + \
+        helm_args += (getattr(self._component, "args",None) or []) + \
             Duration(getattr(self._component, "helm_wait", None)).\
             helm_timeout()
         return cast(bool, execute(helm_args, fail_on_error=False))

--- a/helm/bin/install_prerequisites.py
+++ b/helm/bin/install_prerequisites.py
@@ -382,7 +382,7 @@ class HelmInstallHandler(InstallHandler):
         for helm_setting in \
                 (getattr(self._component, "helm_settings", None) or []):
             helm_args += ["--set", helm_setting]
-        helm_args += (getattr(self._component, "args",None) or []) + \
+        helm_args += (getattr(self._component, "args", None) or []) + \
             Duration(getattr(self._component, "helm_wait", None)).\
             helm_timeout()
         return cast(bool, execute(helm_args, fail_on_error=False))


### PR DESCRIPTION
- values-k3d.yaml: default k3d hostpath for objstore added
- helm_install_ext.py, utils.py: wait for service termination added to wait_termination() and used to wait for dispatcher service termination
- install_prerequisites.py: ability to override list config items with nulls (to remove existing lists, not adding to them) added