### PR TITLE
165. Helm improvements

### DIFF
--- a/helm/afc-ext/values-devel.yaml
+++ b/helm/afc-ext/values-devel.yaml
@@ -4,9 +4,8 @@
 # This work is licensed under the OpenAFC Project License, a copy of which is
 # included with this software program.
 
-# Allows dispatcher access log
+# Enables some development stuff
 
-components:
-  dispatcher:
-    env:
-      AFC_MSGHND_ACCESS_LOG: /proc/self/fd/2
+sharedEnv:
+  devel-env:
+    AFC_DEVEL_ENV: devel

--- a/helm/afc-ext/values.yaml
+++ b/helm/afc-ext/values.yaml
@@ -81,6 +81,10 @@ securityContexts:
 #    in another shared environment block. <IFABSENT> describes what to do if
 #    referred value is absent (see above for values)
 sharedEnv:
+  # Setting AFC_DEVEL_ENV to 'devel' enables certain development options in
+  # certain containers
+  devel-env:
+    AFC_DEVEL_ENV: production
 
 # Dictionary of components. Component roughly corresponds to Docker Compose
 # service. Keys in dictionary are Docker Compose service names, plus there is
@@ -164,6 +168,8 @@ components:
     service:
       type: LoadBalancer
       loadBalancerIpKey: ext-dispatcher
+    sharedEnvKeys:
+      - devel-env
     env:
       AFC_SERVER_NAME: _
       AFC_ENFORCE_HTTPS: "True"

--- a/helm/afc-int/templates/deployment-dispatcher.yaml
+++ b/helm/afc-int/templates/deployment-dispatcher.yaml
@@ -32,5 +32,8 @@ spec:
           env: {{- include "afc.env" . | nindent 12 }}
           ports: {{- include "afc.containerPorts" . | nindent 12 }}
           resources: {{- include "afc.containerResources" . | nindent 12 }}
+          volumeMounts: {{- include "afc.staticVolumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "afc.staticVolumes" . | nindent 8 }}
 
 {{- end -}}

--- a/helm/afc-int/templates/externalsecret-server-cert.yaml
+++ b/helm/afc-int/templates/externalsecret-server-cert.yaml
@@ -1,0 +1,25 @@
+# Copyright (C) 2022 Broadcom. All rights reserved.
+# The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate
+# that owns the software below.
+# This work is licensed under the OpenAFC Project License, a copy of which is
+# included with this software program.
+
+# Server certificate and private key used by dispatcher (if loaded)
+
+{{- $ := mergeOverwrite $ (dict "component" "dispatcher" "secret" "server-cert") }}
+{{- if (include "afc.fullImageName" .) }}
+
+{{- $extSecretDef := merge (dict) (default (dict) (get (default (dict) $.Values.externalSecrets) .secret)) (default (dict) (get (default (dict) $.Values.externalSecrets) "default")) }}
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "afc.secretManifestName" . }}
+  labels: {{- include "afc.commonLabels" . | nindent 4 }}
+spec:
+  {{- include "afc.extSecretStoreRef" . | nindent 2 }}
+  {{- include "afc.refreshInterval" $extSecretDef | indent 2 }}
+  {{- include "afc.extSecretTarget" . | nindent 2 }}
+  {{- include "afc.extSecretData" . | indent 2 }}
+
+{{- end -}}

--- a/helm/afc-int/values-devel.yaml
+++ b/helm/afc-int/values-devel.yaml
@@ -4,7 +4,11 @@
 # This work is licensed under the OpenAFC Project License, a copy of which is
 # included with this software program.
 
-# Allows dispatcher access log
+# Enables development stuff in eligible containers
+
+sharedEnv:
+  devel-env:
+    AFC_DEVEL_ENV: devel
 
 components:
   dispatcher:

--- a/helm/afc-int/values-k3d.yaml
+++ b/helm/afc-int/values-k3d.yaml
@@ -41,4 +41,3 @@ staticVolumes:
 
 externalSecrets:
   image-pull: null
-  server-cert: null

--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -116,10 +116,10 @@ sharedEnv:
     RATAPIFILE_MAIL_PASSWORD: >-
       {{secretFile:ratapi-mail-password:optional}}
     MAIL_USERNAME: ""
-    MAIL_SERVER: ""
-    MAIL_PORT: ""
-    MAIL_USE_TLS: ""
-    MAIL_USE_SSL: ""
+    MAIL_SERVER: "smtp.gmail.com"
+    MAIL_PORT: "465"
+    MAIL_USE_TLS: "False"
+    MAIL_USE_SSL: "True"
     USE_CAPTCHA: ""
     RATAPIFILE_CAPTCHA_SECRET: >-
       {{secretFile:ratapi-captcha-secret:optional}}
@@ -169,6 +169,10 @@ sharedEnv:
     RCACHE_SERVICE_URL: "http://{{host:rcache}}:{{port:rcache:rcache}}"
     RCACHE_RMQ_DSN: >-
       amqp://rcache:rcache@{{host:rmq}}:{{port:rmq:amqp}}/rcache
+  # Setting AFC_DEVEL_ENV to 'devel' enables certain development options in
+  # certain containers
+  devel-env:
+    AFC_DEVEL_ENV: production
 
 # Dictionary of static (non-templated and non-secret) volume definitions.
 # Indexed by volume names
@@ -275,6 +279,8 @@ components:
   ratdb:
     imageName: ratdb-image
     imageRepositoryKey: public
+    sharedEnvKeys:
+      - devel-env
     ports:
       ratdb:
         servicePort: 5432
@@ -290,6 +296,8 @@ components:
     imageRepositoryKey: public
     service:
       loadBalancerIpKey: int-rmq
+    sharedEnvKeys:
+      - devel-env
     ports:
       amqp:
         servicePort: 5672
@@ -323,6 +331,9 @@ components:
     sharedEnvKeys:
       - objst-client
       - objst-common
+      - devel-env
+    mountedSecrets:
+      - server-cert
     ports:
       http:
         servicePort: 80
@@ -364,6 +375,7 @@ components:
       - als-client
       - rcache-client
       - rcache-common
+      - devel-env
     staticVolumeMounts:
       rat_transfer: /mnt/nfs/rat_transfer
       pipe: /pipe
@@ -412,6 +424,7 @@ components:
       - als-client
       - rcache-client
       - rcache-common
+      - devel-env
     mountedSecrets:
       - ratdb-password
       - flask-secret-key
@@ -462,6 +475,7 @@ components:
       - objst-client
       - objst-common
       - als-client
+      - devel-env
     mountedSecrets:
       - ratdb-password
       - rcache-db-password
@@ -497,6 +511,7 @@ components:
       - ratapi-configurator
       - oidc-configurator
       - objst-common
+      - devel-env
     staticVolumeMounts:
         objst-storage: /storage
     mountedSecrets:
@@ -538,6 +553,7 @@ components:
       - als-client
       - rcache-client
       - rcache-common
+      - devel-env
     staticVolumeMounts:
       rat_transfer: /mnt/nfs/rat_transfer
       pipe: /pipe
@@ -658,6 +674,7 @@ components:
     sharedEnvKeys:
       - rcache-client
       - rcache-common
+      - devel-env
     staticVolumeMounts:
       rat_transfer: /rat_transfer
     mountedSecrets:
@@ -678,6 +695,7 @@ components:
       - ratapi-configurator
       - oidc-configurator
       - als-client
+      - devel-env
     mountedSecrets:
       - ratdb-password
       - flask-secret-key
@@ -836,3 +854,19 @@ externalSecrets:
     property: OIDC_CLIENT_ID
   oidc-client-secret:
     property: OIDC_CLIENT_SECRET
+  server-cert:
+    data:
+      # Probably more logical solution could have been storing PKCS12 archive
+      # in remote store and unpacking it with External Secrets templating, but
+      # looks like it adds too much hassle (binary secret, password
+      # provisioning, etc.)
+      # Theoretically, using two separate external secrets for this secret may
+      # cause secret rotation race conditions problems, not sure this would be
+      # a problem in practice though
+      - secretKey: server.cert.pem
+        remoteRef:
+          key: server-cert-pem
+      - secretKey: server.key.pem
+        remoteRef:
+          key: server-key-pem
+    mountPath: /certificates/servers

--- a/helm/bin/helm_install_ext.py
+++ b/helm/bin/helm_install_ext.py
@@ -51,8 +51,8 @@ def main(argv: List[str]) -> None:
         "--mtls", action="store_true",
         help="Enforce mTLS operation (client certificat checking)")
     argument_parser.add_argument(
-        "--access_log", action="store_true",
-        help="Enables dispatcher access log")
+        "--devel", action="store_true",
+        help="Enables development features of various containers")
     argument_parser.add_argument(
         "--wait", metavar="TIMEunit",
         help="Wait for completion for up to given timeout, specified in "
@@ -72,9 +72,6 @@ def main(argv: List[str]) -> None:
         "--set", metavar="VA.RI.AB.LE=VALUE", action="append", default=[],
         help="Additional value setting (overrides some vaslues.yaml variable)")
     argument_parser.add_argument(
-        "--print_values", choices=["yaml", "json"],
-        help="Print consolidated values in given format and exit")
-    argument_parser.add_argument(
         "RELEASE",
         help="Helm release name. 'AUTO' means construct from username and "
         "checkout directory")
@@ -84,8 +81,6 @@ def main(argv: List[str]) -> None:
         sys.exit(1)
 
     args = argument_parser.parse_args(argv)
-
-    set_silent_execute(args.print_values is not None)
 
     tag: Optional[str] = \
         auto_name(kabob=False) if args.tag == AUTO_NAME else args.tag
@@ -125,7 +120,7 @@ def main(argv: List[str]) -> None:
     for cond, filename in \
             [(args.http, "values-http.yaml"),
              (args.mtls, "values-mtls.yaml"),
-             (args.access_log, "values-access_log.yaml")]:
+             (args.devel, "values-devel.yaml")]:
         if not cond:
             continue
         assert isinstance(filename, str)
@@ -149,11 +144,6 @@ def main(argv: List[str]) -> None:
     # ... timeout
     if args.wait:
         install_args += ["--wait", "--timeout", args.wait]
-
-    if args.print_values:
-        print_helm_values(helm_args=install_args,
-                          print_format=args.print_values)
-        return
 
     # Executing helm install
     execute(install_args)

--- a/helm/bin/k3d_cluster_create.py
+++ b/helm/bin/k3d_cluster_create.py
@@ -106,10 +106,9 @@ def main(argv: List[str]) -> None:
         f"subkey). Known nodeport names: "
         f"{', '.join(sorted(known_nodeports.keys()))}). For this to work "
         f"ports should also be exposed during helm installation (--expose "
-        f"switch of helm_install.py). HOST_PPORTn are unused host ports (if "
-        f"unspecified - some unused ports are chosen). Defaults may be found "
-        f"in script's config file. This parameter may be specified more than "
-        f"once")
+        f"switch of helm_install.py). HOST_PORTn are unused host ports (if "
+        f"unspecified - some unused ports are chosen). This parameter may be "
+        "specified more than once")
     argument_parser.add_argument(
         "--delete", action="store_true",
         help="Delete cluster if it is running. Not very logical, but makes "

--- a/helm/bin/push_images.py
+++ b/helm/bin/push_images.py
@@ -32,7 +32,7 @@ def main(argv: List[str]) -> None:
     argument_parser.add_argument(
         "--k3d_reg", metavar="[NAME][:PORT] or DEFAULT",
         help="Push images to k3d image registry - either explicitly specified "
-        "or the default (default is the only k3d registryt, running locally)")
+        "or the default (default is the only k3d registry, running locally)")
     argument_parser.add_argument(
         "--registry", metavar="PULL_REGISTRY",
         help="Image registry Kubernetes will pull images from")

--- a/tools/secrets/README.md
+++ b/tools/secrets/README.md
@@ -69,7 +69,7 @@ stringData:
 ```
 Note how YAML format allows to store JSON and YAML files in verbatim secrets section (`JSON_SECRET1.json`, `YAML_SECRET1.yam`).
 
-Keys of `data`/`stringData` sections are used as file names (in Kubernetes they also can be used as environment variables). One manifest may contain several keys, but for simplicity of management AFC uses one key per secrest manifest (several manifests may be stored in a single file, using `---` separator).
+Keys of `data`/`stringData` sections are used as file names (in Kubernetes they also can be used as environment variables). One manifest may contain several keys, but for simplicity of management AFC uses one key per secret manifest (several manifests may be stored in a single file, using `---` separator).
 
 This Kubernetes secret manifest format is used to store secrets (at least in Compose environment - Kubernetes storage mechanism may evolve towards something safer/more appropriate).
 

--- a/tools/secrets/templates/afc_secrets.yaml
+++ b/tools/secrets/templates/afc_secrets.yaml
@@ -109,6 +109,8 @@ stringData:
     OIDC_CLIENT_SECRET: ""
 ---
 # Server certificate used by dispatcher
+# Secret value below is a copy of dispatcher/certs/servers/server.cert.pem - a
+# self-signed certificate (don't use it in production!)
 apiVersion: v1
 kind: Secret
 metadata:
@@ -151,6 +153,8 @@ stringData:
         -----END CERTIFICATE-----
 ---
 # Server private key used by dispatcher
+# Secret value below is a copy of dispatcher/certs/servers/server.key.pem - a
+# self-signed private key (don't use it in production!)
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tools/secrets/templates/afc_secrets.yaml
+++ b/tools/secrets/templates/afc_secrets.yaml
@@ -107,3 +107,104 @@ metadata:
     name: oidc-client-secret
 stringData:
     OIDC_CLIENT_SECRET: ""
+---
+# Server certificate used by dispatcher
+apiVersion: v1
+kind: Secret
+metadata:
+    name: server-cert-pem
+stringData:
+    server.cert.pem: |
+        -----BEGIN CERTIFICATE-----
+        MIIF6DCCA9CgAwIBAgIUTldfidz38+Lnukf4EC6xQ4AvLQYwDQYJKoZIhvcNAQEL
+        BQAwWjELMAkGA1UEBhMCSUwxDzANBgNVBAgMBklzcmFlbDERMA8GA1UEBwwIVGVs
+        IEF2aXYxETAPBgNVBAoMCEJyb2FkY29tMRQwEgYDVQQDDAtBRkMgVGVzdGluZzAe
+        Fw0yMzA1MzEwODQ1NTZaFw0yNTA2MTkwODQ1NTZaMFcxCzAJBgNVBAYTAklMMQ8w
+        DQYDVQQIDAZJc3JhZWwxETAPBgNVBAcMCFRlbCBBdml2MREwDwYDVQQKDAhCcm9h
+        ZGNvbTERMA8GA1UEAwwIYmV0YV9zZXIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+        ggIKAoICAQDg4U+tOhn4ZgSyo826i/bpbXzXnKI7gQgmaPygF8bA/mhuXeNBHHbU
+        sTJUVNjvPFINyEeE23mGGPZ1i2JQTXsuSTYj1MLOC1ScKR/hE8+L9TxOoJPtfY1d
+        hoXzgofjJI6aR9cmr6HT8Hg8gJDoSRMrLLTTEWRh36d/KgQlrPYQmtHKdstvyJop
+        5uPIy/3mfEDVy0EoXsq3spLMTLxdD8gUrBuYT56FS0q9XwNCI/+vGn9RYMOZbzA9
+        s8f8vES3AFwxuBAu1H+zoyPgFa+dGeHWoW9feu/LpSQOtK5hjlqeHWGNdHNdcc6s
+        GQEVdGHqt+BGj6nd7jUCNqbNet3jWjKQCn0WnmxdnM/2gR+djhvo7B9puwHphsSx
+        8r8VghfHyNL3RytYDezONUunFG/mU2P7RzFTc2PcqxtAfz4K4REIRQwqvW4nBv2K
+        40Thgcc2SBPCoihoNdHUxlZPO5lwJdv2k07ztc35ujUMtBiqmQWQnoVkpd9OXYHV
+        rI6F7TK8DP1MP1w+L7QNuzyFEtxPl2YjWNqeuWf33L74/IEL0NWhHW1yIJE9+0L3
+        1LLrhKnbk0+C0pNFaLP5UDeqDQejvAKn5NVMhQL3i4rtdn5lHnpSd803EiBTs6ZW
+        TRG351AY+tWonY4eNMgfKLoA4tc9e9iENBJI/efkytLp3K6zNdISDQIDAQABo4Go
+        MIGlMB8GA1UdIwQYMBaAFJqp1Ecmnjbynuf2eYRHR8ekZOmzMAwGA1UdEwEB/wQC
+        MAAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDgYDVR0PAQH/BAQDAgWgMDAGA1UdEQQp
+        MCeCH3dlYi1paGwtd2NjLTAxLmlobC5icm9hZGNvbS5uZXSHBAq7gCgwHQYDVR0O
+        BBYEFMh+ORROXNcfoSAuTn92epuRvtNfMA0GCSqGSIb3DQEBCwUAA4ICAQClwzvh
+        gNyPG2lisJ/EooDDX22gxUInb7cmi8gKX+pNrT4UJqwgo7olgWVfJwyBnI+u7fs1
+        dXOyu4zaoSmnh2TJLtLukWhPcxFgVdfo5D0CdmV9c02qgWt+TXbApATK7F7857P6
+        sdPTbqbMAtn4Z48uGt+rluOyTO3CJ9ZzIJHuegzZEFjX24HtXXVdRLMRA1Cauxhb
+        2b+ty+k7JB5jIwJ9t+PZzb2ktKy06yGqjYyazy3RpVAxWi8aAJuBQGxHmy0ZBNLx
+        0JaqDj+D+zc+U0jezhlm3II+o0cq7THCKhZPGbZUIszTN9CFtByKoIzO4jBdnYkw
+        0d+Kws/A6dfPv8janfxTUlS50P1+/5OeZCMc7g83KMzWzIBjye16FMENJhPxhuDD
+        y1ylCTnEC5YZMCfikBo9McVft6MN/z60sQgFF2TNYqEFVYpr3Z/qw8EoBmKbl/8i
+        HU9Ac8GdsQFTmrFaFtlSSh/Cfq41iVlLTKjr54YJ2QvjLN+XD6geTBWTfkYIryv/
+        9IkOcg3bLsfXp9LD5RVe0t4FdgfutYYOzNI0FMa5Q6H2C0yX+6NW0pYQT4Yny/pT
+        xl7rTSy9qSd1ChkxGNHzzwrFQaPA1E+Aq4Df5J1p+sVaL17vsEV7ClIWSJXMbIP5
+        auYOE6NvyXIli3UoafQ0TIzUfB9ab+coVN/Txw==
+        -----END CERTIFICATE-----
+---
+# Server private key used by dispatcher
+apiVersion: v1
+kind: Secret
+metadata:
+    name: server-key-pem
+stringData:
+    server.key.pem: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIJKgIBAAKCAgEA4OFPrToZ+GYEsqPNuov26W1815yiO4EIJmj8oBfGwP5obl3j
+        QRx21LEyVFTY7zxSDchHhNt5hhj2dYtiUE17Lkk2I9TCzgtUnCkf4RPPi/U8TqCT
+        7X2NXYaF84KH4ySOmkfXJq+h0/B4PICQ6EkTKyy00xFkYd+nfyoEJaz2EJrRynbL
+        b8iaKebjyMv95nxA1ctBKF7Kt7KSzEy8XQ/IFKwbmE+ehUtKvV8DQiP/rxp/UWDD
+        mW8wPbPH/LxEtwBcMbgQLtR/s6Mj4BWvnRnh1qFvX3rvy6UkDrSuYY5anh1hjXRz
+        XXHOrBkBFXRh6rfgRo+p3e41AjamzXrd41oykAp9Fp5sXZzP9oEfnY4b6OwfabsB
+        6YbEsfK/FYIXx8jS90crWA3szjVLpxRv5lNj+0cxU3Nj3KsbQH8+CuERCEUMKr1u
+        Jwb9iuNE4YHHNkgTwqIoaDXR1MZWTzuZcCXb9pNO87XN+bo1DLQYqpkFkJ6FZKXf
+        Tl2B1ayOhe0yvAz9TD9cPi+0Dbs8hRLcT5dmI1janrln99y++PyBC9DVoR1tciCR
+        PftC99Sy64Sp25NPgtKTRWiz+VA3qg0Ho7wCp+TVTIUC94uK7XZ+ZR56UnfNNxIg
+        U7OmVk0Rt+dQGPrVqJ2OHjTIHyi6AOLXPXvYhDQSSP3n5MrS6dyuszXSEg0CAwEA
+        AQKCAgEAhgZiqThOkBelRx6PF1Yhoz9ov0wP+GzPgazimztwbkdx0A1Oyth/DgZJ
+        m68x12tY7/PkhA8WH1CzWpzmzDtRZeWmSbadH5XrKGLuKAPZl21iMu5LG6jPXuU0
+        4ktyV3LLNrIITXsxdJIF5vEs6/PZY8ryPjVIYXidaBGPhTDPOlg7HnKsjoO9Nanx
+        KhRBz2NQdNr9i2TrZo4cJXy6arBkK8XjcGRLct/LvI9q7rlrwl2Fcee8y65TzwJd
+        94fxYCvrxooPwwlMzrA1SnFCR9xMF9IBAaPQVMuocMdIgsYHxeJ26Ip100Rny3Pf
+        jHzferd6CDPJJoa4uwf9Y8uNgNmZ9dbqiJR+tgdR8WuG2Bn3NzOOeN8tipPzDYuf
+        2jHO117IsgEPugbW0IQcpee3gZf/7iqaJVIIT6c0Bq2tSYcpNSRCYdOx9rR5KVH7
+        Qv2KWKl/rHHVw38jX9HxmwFjZhF6Lc4hQVHc9ZOqY0gwbQCLtqQKHOU8RcgbrjhX
+        lEq7le5God2ukNctHU/CSvSF1LXRmrX+xQSdawwtpaRUtgx7YgG2cwo48rox/d3d
+        Knmf8sArMkvpNCAIj7oRI8FS34NbvKUYiMqqIEUinwmemA9s7QK/8DfTFOzDS9Z4
+        hXNrU38SfQGCGSQcvwbDCjrCgQqpxoGhMYRUqPuwVo9PyuhPmxUCggEBAPT5XY3H
+        vnXL6Oust2ypPvzOZ0qjDCQGWjkFIGyWuZ7RFzjPJYKBeyCH/HqQuEeWsN29gj+B
+        UY9HyN9PDhEaGGRahgYmRKAOLs8BHJ7yzNTLZef5HiDFFkZ26n/QmQQGVxdvXpV5
+        rLYR4XtIvCKkooJURqkrIATTENilin09iVpYbozKKFvSYmv+HN0+t03XxqtxnGVj
+        aS+lM0UeV8dWypce9Ipu1gSPLy67uSJ8p0oa99zo2OPgPjf2r9Rj8+oKLTf89aK4
+        Ev//fukbeMwtRLl6hy97gUCvyoNdgXzEIjI+rdMC13LM26BvPxgtT2mqZs7ocU8Q
+        qptTEmKfVFlnNzMCggEBAOsAa2yGOE3MEaNDaOT9cOo2frpxevOjrU/rZ0Ds5ZHl
+        tpiM5qm/Grjd8tbDmQo2Xcarqnq37G9ce7x1JNRMdD42UbudTx0QSg3gi6FFxZVj
+        ccoDACUkIuT7NbUQV/LwCNV3/ZsWX75yanWhZUAtaAu8ZN/7dtpXVXcmZbYgs0xm
+        zAMlHlSDqMYeol2uyPRX0jdcDSc3kh6pGAssBpelenALrBjdQn++4S57iWeiKUfc
+        qvMtq9gHKcIRL3o/zwDln26hrZ7qgd6+hUYqG2MREs4vOPlpPwN+m2bJKrRKE0dO
+        +zylLJ5GaBn3Bv34wiuDZZSQt1ChMvXmKf8OKBZEkb8CggEAbXGGwVPOnFPoEHpO
+        TCZktI8GCItFXkbUQgsvTDQeY3yockHhUSfFuWfnfV5wZdNF2xrSOMruhCOe810f
+        PLa61QK4Q8EPAa60bNjjT4PLzPm94mAifKNwazSvWUD5S5oFiLvBtufwKDte0DRT
+        kOqai71ZADT7Dgy5xwBWGdPHLGy7nvymATfBrtuNS668N/PBl1CffZBnKtkUSbnf
+        n3f/9Hno6HvR86GAg9FsSaMFHg9kUvZYB55kTZ5ROYMaMqIvR4ckunigTGx552zV
+        j+pdfLvn72eu/BZNVFkPA42gdXAZOl9Xn7s0F737ozKC+wMdAS1Jifg5MEFxwkvK
+        ZFK/jwKCAQEAiCUmFylrVSb00PEsw/1QfWA06y7zXFNnBPYMS8Dy/yNmNdrrh0v/
+        3zo2hdWrxA7bJU4u5gnIIHwj83qqa5QfhCtUDq2EOAJH5OJCApy5a2LBeZdjbiER
+        VjdzVgKx8Ty+4W0yr7a2oU8H/j4SuquTq7jpeBnnMXeHPBAyvOEU/x5O80N93tin
+        3p/A0SWBpo16bDgYJrA7JygvlclbyF9GH8OjYIRPElMzggpwAGoiIE/nehrrg6wi
+        tRvftaNh+dMOGrnwLDEQLEuUSqH6W9p4WpthFp2ytAOVZGcHJowDvzwysV/ACbIg
+        fWpv0pNbanolT3zHtx6st2kwy2MYNk5jYQKCAQEA6hsqOztjsDs3Q9GQMreKgzrp
+        FrBG6zSCJYsskWofl87kiAeztGmDCMtW0SiKAGwr1QxZA2qENUS/+Pdf1tmx7nIJ
+        Y+7nULd1BWKpiFxOIzY8lQtqItEpq4sJtp4q6grvHu1N6wfIyVTl75H4P/YlQo+Q
+        nOP8O0RiSE63sEgyWxIzi4BeiTIHfpUDw4LGjIqZAdDbGbsaLx4CLSMoxhxHKPzu
+        Yy+17mzAZAE5otdKzqCxjXjxKQtBOUA9n8Ye6e2ekoFXMmJI7DiuaVacuWQgOhCO
+        oqmuTnrGXxHrWwS7j0Bt9SZhHXu0b89faPegGk9pp5wrCxZrXlLq4TvT/BuFsA==
+        -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
- helm_install_*.py's --access_log replaced with --devel that enables Gery's development features in pods where they are enabled
- Brought server-cert secret to k3d platform
- Removed helm_install_*.py's --print_vaalues, as it does not quite work

Closes #165