### PR TITLE
171. Renaming afc-server image to webui-image

### DIFF
--- a/helm/afc-int/values.yaml
+++ b/helm/afc-int/values.yaml
@@ -350,7 +350,7 @@ components:
         servicePort: 3000
         nodePort: 31001
   rat-server:
-    imageName: afc-server
+    imageName: webui-image
     imageRepositoryKey: private
     service:
       hostname: webui

--- a/tests/regression/docker-compose.yaml
+++ b/tests/regression/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
     dns_search: [.]
 
   rat_server:
-    image: ${PRIV_REPO:-ghcr.io/open-afc-project}/afc-server:${TAG:-latest}
+    image: ${PRIV_REPO:-ghcr.io/open-afc-project}/webui-image:${TAG:-latest}
     volumes:
       - ${VOL_H_DB}:${VOL_C_DB}
       - ./pipe:/pipe

--- a/tests/regression/regression.sh
+++ b/tests/regression/regression.sh
@@ -9,7 +9,7 @@
 PRIV_REPO="${PRIV_REPO:=ghcr.io/open-afc-project}"
 PUB_REPO="${PUB_REPO:=ghcr.io/open-afc-project}"
 
-SRV="${PRIV_REPO}/afc-server"                                         # server image
+WEBUI="${PRIV_REPO}/webui-image"                             # Web server image
 MSGHND="${PRIV_REPO}/afc-msghnd"                             # msghnd image
 OBJST="${PUB_REPO}/objstorage-image"                         # object storage
 RATDB=${PUB_REPO}"/ratdb-image"                                  # ratdb image
@@ -122,66 +122,109 @@ build_dev_server() {
   docker_build tests/Dockerfile ${RTEST_DI}:${tag}
   check_ret $?
 
+  build_pids=(); build_names=(); failed_images=()
+
   # build in parallel server docker prereq images (preinstall and docker_for_build)
     docker_build_and_push ${wd}/worker/Dockerfile.build ${WORKER_AL_D4B}:${tag} ${push} &
+    build_pids+=( $! ) ; build_names+=( ${WORKER_AL_D4B} )
+
     docker_build_and_push ${wd}/worker/Dockerfile.preinstall ${WORKER_AL_PRINST}:${tag} ${push} &
+    build_pids+=( $! ) ; build_names+=( ${WORKER_AL_PRINST} )
 
   msg "wait for prereqs to be built"
   # wait for background jobs to be done
-  wait
+  for i in ${!build_pids[@]}; do
+    if ! wait ${build_pids[$i]}; then
+      failed_images+=( ${build_names[$i]} )
+    fi
+  done
+  build_pids=(); build_names=()
   msg "prereqs are built"
 
   # build of ULS dockers
   EXT_ARGS="--build-arg BLD_TAG=${tag} --build-arg PRINST_TAG=${tag} --build-arg BLD_NAME=${WORKER_AL_D4B} --build-arg PRINST_NAME=${WORKER_AL_PRINST} --build-arg BUILDREV=${BUILDREV}"
   docker_build_and_push ${wd}/uls/Dockerfile-uls_service ${ULS_DOWNLOADER}:${tag} ${push} "${EXT_ARGS}" &
+  build_pids+=( $! ) ; build_names+=( ${ULS_DOWNLOADER} )
 
   # build msghnd  (flask + gunicorn)
   docker_build_and_push ${wd}/msghnd/Dockerfile ${MSGHND}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${MSGHND} )
 
   # build worker image
   EXT_ARGS="--build-arg BLD_TAG=${tag} --build-arg PRINST_TAG=${tag} --build-arg BLD_NAME=${WORKER_AL_D4B} --build-arg PRINST_NAME=${WORKER_AL_PRINST} --build-arg BUILDREV=worker"
   docker_build_and_push ${wd}/worker/Dockerfile   ${WORKER}:${tag} ${push} "${EXT_ARGS}" &
+  build_pids+=( $! ) ; build_names+=( ${WORKER} )
 
   # build afc ratdb docker image
   docker_build_and_push ${wd}/ratdb/Dockerfile ${RATDB}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${RATDB} )
 
   # build afc dynamic data storage image
   docker_build_and_push ${wd}/objstorage/Dockerfile ${OBJST}:${tag} ${push}&
+  build_pids+=( $! ) ; build_names+=( ${OBJST} )
   cd ${wd}
 
   # build afc rabbit MQ docker image
   docker_build_and_push ${wd}/rabbitmq/Dockerfile ${RMQ}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${RMQ} )
 
   # build afc dispatcher docker image
   docker_build_and_push ${wd}/dispatcher/Dockerfile ${DISPATCHER}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${DISPATCHER} )
 
   # build afc server docker image
   EXT_ARGS="--build-arg BUILDREV=${BUILDREV}"
-  docker_build_and_push ${wd}/rat_server/Dockerfile ${SRV}:${tag}  ${push} "${EXT_ARGS}"
+  docker_build_and_push ${wd}/rat_server/Dockerfile ${WEBUI}:${tag}  ${push} "${EXT_ARGS}"
+  build_pids+=( $! ) ; build_names+=( ${WEBUI} )
 
   # build ALS-related images
   docker_build_and_push ${wd}/als/Dockerfile.siphon ${ALS_SIPHON}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${ALS_SIPHON} )
+
   cd ${wd}/als && docker_build_and_push Dockerfile.kafka ${ALS_KAFKA}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${ALS_KAFKA} )
+
   cd ${wd}/bulk_postgres && docker_build_and_push Dockerfile ${BULK_POSTGRES}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${BULK_POSTGRES} )
   cd ${wd}
 
    # build cert db image
   docker_build_and_push ${wd}/cert_db/Dockerfile ${CERT_DB}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${CERT_DB} )
 
   # Build Request Cache
   docker_build_and_push ${wd}/rcache/Dockerfile ${RCACHE}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${RCACHE} )
 
   # Build AFC Server
   docker_build_and_push ${wd}/afc_server/Dockerfile ${AFC_SERVER}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${AFC_SERVER} )
 
   # Build Prometheus-related images
   cd ${wd}/prometheus && docker_build_and_push Dockerfile-prometheus ${PROMETHEUS}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${PROMETHEUS} )
+
   cd ${wd}/prometheus && docker_build_and_push Dockerfile-cadvisor ${CADVISOR}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${CADVISOR} )
+
   cd ${wd}/prometheus && docker_build_and_push Dockerfile-nginxexporter ${NGINXEXPORTER}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${NGINXEXPORTER} )
+
   cd ${wd}/prometheus && docker_build_and_push Dockerfile-grafana ${GRAFANA}:${tag} ${push} &
+  build_pids+=( $! ) ; build_names+=( ${GRAFANA} )
 
   msg "wait for all images to be built"
-  wait
+
+  for i in ${!build_pids[@]}; do
+    if ! wait ${build_pids[$i]}; then
+      failed_images+=( ${build_names[$i]} )
+    fi
+  done
+
+  if [ ${#failed_images[@]} -ne 0 ]; then
+    msg "Failed images:  ${failed_images[@]}"
+    exit 1
+  fi
   msg "-done-"
 }
 # Local Variables:

--- a/tests/regression/regression.sh
+++ b/tests/regression/regression.sh
@@ -160,7 +160,7 @@ build_dev_server() {
   build_pids+=( $! ) ; build_names+=( ${RATDB} )
 
   # build afc dynamic data storage image
-  docker_build_and_push ${wd}/objstorage/Dockerfile ${OBJST}:${tag} ${push}&
+  docker_build_and_push ${wd}/objstorage/Dockerfile ${OBJST}:${tag} ${push} &
   build_pids+=( $! ) ; build_names+=( ${OBJST} )
   cd ${wd}
 
@@ -174,7 +174,7 @@ build_dev_server() {
 
   # build afc server docker image
   EXT_ARGS="--build-arg BUILDREV=${BUILDREV}"
-  docker_build_and_push ${wd}/rat_server/Dockerfile ${WEBUI}:${tag}  ${push} "${EXT_ARGS}"
+  docker_build_and_push ${wd}/rat_server/Dockerfile ${WEBUI}:${tag}  ${push} "${EXT_ARGS}" &
   build_pids+=( $! ) ; build_names+=( ${WEBUI} )
 
   # build ALS-related images


### PR DESCRIPTION
Because this entity has 3 names (rat-server, webui, afcserver) which is two too much. Also SRV in regression.sh renamed to WEBUI
Most of changes in regression.sh are from #167 to simplify future merging.

Checked on k3d.

This RB is draft because #167 should be merged first. Other than that it is good to go.

Closes #171.