### PR TITLE
187. Typo fixed that prevented Rcache invalidation logging

### DIFF
--- a/rcache/rcache_service.py
+++ b/rcache/rcache_service.py
@@ -261,7 +261,7 @@ class RcacheService:
             else:
                 for ruleset_id in invalidation_req.ruleset_ids:
                     self._log_invalidation(invalidate_ruleset_id=ruleset_id)
-        elif isinstance(invalidation_req, RcacheInvalidateReq):
+        elif isinstance(invalidation_req, RcacheSpatialInvalidateReq):
             for tile in invalidation_req.tiles:
                 self._log_invalidation(invalidate_tile=tile)
         self._invalidation_queue.put_nowait(invalidation_req)


### PR DESCRIPTION
That was the only damage made by this typo
Result tested in Compose