### PR TITLE
240. Changing mtls_dn.dn_text column type from String to Text in Alembic upgrade script

### DIFF
--- a/als/als_migrations/versions/2024_10_31-87a874c761f8_mtls_dn_table_added.py
+++ b/als/als_migrations/versions/2024_10_31-87a874c761f8_mtls_dn_table_added.py
@@ -20,7 +20,7 @@ def upgrade() -> None:
     op.create_table(
         "mtls_dn",
         sa.Column("dn_json", sa_pg.JSONB()),
-        sa.Column("dn_text", sa.String(), index=True),
+        sa.Column("dn_text", sa.Text(), index=True),
         sa.Column("dn_text_digest", sa_pg.UUID(), index=True),
         sa.Column("month_idx", sa.SmallInteger()))
     op.create_primary_key(


### PR DESCRIPTION
It is declared as Text in ALS.sql, but somehow this did not create problem with Postgres from containers.
GCE Postgres however treat this as an error, so type in Alembic script changed to Text

Closes #240