### PR TITLE
257.  cert_db fixes and improvements

### DIFF
--- a/als/Dockerfile.siphon
+++ b/als/Dockerfile.siphon
@@ -113,4 +113,4 @@ ENTRYPOINT /usr/app/als_siphon.py init_siphon \
     --als_alembic_config=$ALEMBIC_CONFIG \
     --als_alembic_initial_version=$ALS_ALEMBIC_INITIAL_VERSION
 
-HEALTHCHECK CMD test ! `find $SIPHON_TOUCH_FILE -mmin 1`
+HEALTHCHECK CMD test `find $SIPHON_TOUCH_FILE -mmin -1`

--- a/cert_db/Dockerfile
+++ b/cert_db/Dockerfile
@@ -59,16 +59,30 @@ RUN addgroup -g 1003 fbrat && \
 adduser -g '' -D -u 1003 -G fbrat -h /var/lib/fbrat -s /sbin/nologin fbrat && \
 chown fbrat:fbrat /var/lib/fbrat
 #
+# Prevent Rcache client initialization (fails on parameter checking)
+ENV RCACHE_ENABLED=False
+# Space-separated list of regions to sweep
+ENV SWEEP_REGIONS="US CA"
+# Sweep periodicity in /etc/periodic units (15min,hourly,daily,weekly,monthly)
+ENV SWEEP_PERIOD=daily
+# REST request timeout in seconds
+ENV REQUEST_TIMEOUT_SEC=500
+# Make all environment variables available to cronjobs
+RUN env >> /etc/environment
+
 LABEL revision="afc-cert_db"
 WORKDIR /wd
 COPY cert_db/entrypoint.sh /
 # Add debugging env if configured
 ARG AFC_DEVEL_ENV=${AFC_DEVEL_ENV:-production}
-COPY cert_db/devel.sh /wd/
-RUN chmod +x /wd/devel.sh
+COPY cert_db/devel.sh cert_db/sweep.sh /wd/
+RUN chmod +x /wd/devel.sh /wd/sweep.sh
 RUN /wd/devel.sh
 #
-ADD cert_db/sweep.sh /etc/periodic/daily/
-RUN chmod 744 /etc/periodic/daily/sweep.sh
+RUN mkdir -p /etc/periodic/$SWEEP_PERIOD
+RUN ln -s /wd/sweep.sh /etc/periodic/$SWEEP_PERIOD/sweep.sh
+RUN chmod 744 /etc/periodic/$SWEEP_PERIOD/sweep.sh
 RUN chmod +x /entrypoint.sh
 CMD ["/entrypoint.sh"]
+
+HEALTHCHECK --start-period=30m CMD test `find /wd/touchfile -mmtime -3`

--- a/cert_db/entrypoint.sh
+++ b/cert_db/entrypoint.sh
@@ -6,10 +6,8 @@
 # a copy of which is included with this software program
 #
 
+/wd/sweep.sh
 if [[ -z "${K8S_CRON}" ]]; then
   crond -b
   sleep infinity
-else
-  /usr/bin/rat-manage-api cert_id sweep --country US
-  /usr/bin/rat-manage-api cert_id sweep --country CA
 fi

--- a/cert_db/requirements.txt
+++ b/cert_db/requirements.txt
@@ -10,6 +10,7 @@ Flask-Script==2.0.5
 Jinja2==3.1.4
 json5==0.9.10
 prettytable==3.5.0
+prometheus-client==0.17.1
 python_dateutil==2.8.2
 pyxdg==0.28
 email-validator==1.3.0

--- a/cert_db/sweep.sh
+++ b/cert_db/sweep.sh
@@ -6,5 +6,12 @@
 # a copy of which is included with this software program
 #
 
-/usr/bin/rat-manage-api cert_id sweep --country US
-/usr/bin/rat-manage-api cert_id sweep --country CA
+result=success
+for region in $SWEEP_REGIONS
+do
+    /usr/bin/rat-manage-api cert_id sweep --country $region || result=fail
+done
+if [ "$result" == "success" ]
+then
+	touch /wd/touchfile
+fi

--- a/src/afc-packages/pkgs.cert_db
+++ b/src/afc-packages/pkgs.cert_db
@@ -9,3 +9,4 @@
 /wd/afc-packages/rcache
 /wd/afc-packages/healthchecks
 /wd/afc-packages/secret_utils
+/wd/afc-packages/prometheus_utils

--- a/src/ratapi/ratapi/manage.py
+++ b/src/ratapi/ratapi/manage.py
@@ -890,7 +890,10 @@ class CertIdSweep(Command):
                 'user-agent': 'rat_server/1.0'
             }
             try:
-                with requests.get(url, headers, stream=True) as r:
+                timeout = os.environ.get("REQUEST_TIMEOUT_SEC")
+                if timeout is not None:
+                    timeout = float(timeout)
+                with requests.get(url, headers, stream=True, timeout=timeout) as r:
                     r.raise_for_status()
 
                     local_filename = "/tmp/SD6_list.csv"
@@ -960,7 +963,7 @@ class CertIdSweep(Command):
 
         now = datetime.datetime.now()
         with flaskapp.app_context():
-            url = 'https://apps.fcc.gov/oetcf/eas/reports/GenericSearchResult.cfm?RequestTimeout=500'
+            url = f'https://apps.fcc.gov/oetcf/eas/reports/GenericSearchResult.cfm?RequestTimeout={os.environ.get("REQUEST_TIMEOUT_SEC", "500")}'
             headers = {
                 'accept': 'text/html,application/xhtml+xml,application/xml',
                 'cache-control': 'max-age=0',
@@ -969,7 +972,10 @@ class CertIdSweep(Command):
             }
 
             try:
-                resp = requests.post(url, headers=headers, data=data)
+                timeout = os.environ.get("REQUEST_TIMEOUT_SEC")
+                if timeout is not None:
+                    timeout = float(timeout)
+                resp = requests.post(url, headers=headers, data=data, timeout=timeout)
                 if resp.status_code == 200:
                     try:
                         from xml.etree import ElementTree

--- a/src/ratapi/ratapi/views/ratafc.py
+++ b/src/ratapi/ratapi/views/ratafc.py
@@ -373,12 +373,14 @@ response_map = {
     afctask.Task.STAT_PROGRESS: in_progress
 }
 
-
-rcache_settings = RcacheClientSettings()
-# In this validation rcache is True to handle 'not update_on_send' case
-rcache_settings.validate_for(db=True, rmq=True, rcache=True)
-rcache = RcacheClient(rcache_settings, rmq_receiver=True) \
-    if rcache_settings.enabled else None
+if os.environ.get('RCACHE_ENABLED', '').lower() in ('0', 'no', 'false', '-'):
+    rcache = None
+else:
+    rcache_settings = RcacheClientSettings()
+    # In this validation rcache is True to handle 'not update_on_send' case
+    rcache_settings.validate_for(db=True, rmq=True, rcache=True)
+    rcache = RcacheClient(rcache_settings, rmq_receiver=True) \
+        if rcache_settings.enabled else None
 
 
 class ReqInfo(NamedTuple):


### PR DESCRIPTION
- Crashes, caused by dependencies of ratafc, included by rat-manage-api fixed
- Certificate retrievals rest invocations now have timeouts, set by REQUEST_TIMEOUT_SEC
- List of regions to sweep made configurable via REQUEST_TIMEOUT_SEC
- Sweep periodicity made configurable via REQUEST_TIMEOUT_SEC
- First invocation of sweep.sh is always in foreground, to make it crash and burn explicitly
- Healthcheck, based on last successful sweep added