### PR TITLE
269. Adding timezones to ULS-related timetags

### DIFF
--- a/uls/uls_service.py
+++ b/uls/uls_service.py
@@ -921,7 +921,8 @@ class AlsRecord(pydantic.BaseModel):
     def now(self, field_name: str) -> None:
         """ Sets given field to current datetime as ISO-formatted string """
         assert field_name.endswith("_time")
-        setattr(self, field_name, datetime.datetime.utcnow().isoformat())
+        setattr(self, field_name,
+                datetime.datetime.now(datetime.timezone.utc).isoformat())
 
 
 def main(argv: List[str]) -> None:

--- a/uls/uls_service_healthcheck.py
+++ b/uls/uls_service_healthcheck.py
@@ -158,7 +158,7 @@ def expired(event_td: Optional[datetime.datetime],
         return False
     if event_td is None:
         return True
-    return (datetime.datetime.utcnow() - event_td) > \
+    return (datetime.datetime.now(datetime.timezone.utc) - event_td) > \
         datetime.timedelta(hours=max_age_hr)
 
 
@@ -291,7 +291,8 @@ def email_if_needed(state_db: StateDb, settings: Any) -> None:
         message_body += \
             f"{heading}{'Unknown' if et is None else et.isoformat()}"
         if et is not None:
-            message_body += f" ({datetime.datetime.utcnow() - et} ago)"
+            message_body += \
+                f" ({datetime.datetime.now(datetime.timezone.utc) - et} ago)"
         message_body += "\n"
 
     for reg in sorted(set(cast(str, r) for r in reg_data_changes.keys()) |
@@ -301,7 +302,8 @@ def email_if_needed(state_db: StateDb, settings: Any) -> None:
             (f"FS data for region '{reg}' last time updated in: "
              f"{'Unknown' if et is None else et.isoformat()}")
         if et is not None:
-            message_body += f" ({datetime.datetime.utcnow() - et} ago)"
+            message_body += \
+                f" ({datetime.datetime.now(datetime.timezone.utc) - et} ago)"
         message_body += "\n"
     if email_milestone == DownloaderMilestone.AlarmSent:
         log_info = state_db.read_last_log(log_type=LogType.Last)

--- a/uls/uls_service_state_db.py
+++ b/uls/uls_service_state_db.py
@@ -458,7 +458,7 @@ class StateDb:
             ops.append(
                 sa.delete(table).where(table.c.region.notin_(all_regions)).
                 where(table.c.milestone == milestone.name))
-        timestamp = datetime.datetime.utcnow()
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
         ins = sa_pg.insert(table).\
             values(
                 [{"milestone": milestone.name, "region": region or "",
@@ -496,7 +496,7 @@ class StateDb:
         table = self.metadata.tables[self.ALARM_TABLE_NAME]
         ops: List[Any] = [sa.delete(table)]
         if reasons:
-            timestamp = datetime.datetime.utcnow()
+            timestamp = datetime.datetime.now(datetime.timezone.utc)
             values: List[Dict[str, Any]] = []
             for alarm_type, alarm_reasons in reasons.items():
                 values += [{"alarm_type": alarm_type.name,
@@ -531,7 +531,7 @@ class StateDb:
         table = self.metadata.tables[self.LOG_TABLE_NAME]
         ins = sa_pg.insert(table).\
             values(log_type=log_type.name, text=log,
-                   timestamp=datetime.datetime.utcnow())
+                   timestamp=datetime.datetime.now(datetime.timezone.utc))
         ins = \
             ins.on_conflict_do_update(
                 index_elements=["log_type"],
@@ -569,7 +569,7 @@ class StateDb:
         ops: List[Any] = \
             [sa.delete(table).where(table.c.check_type == check_type.name)]
         if results:
-            timestamp = datetime.datetime.utcnow()
+            timestamp = datetime.datetime.now(datetime.timezone.utc)
             ops.append(
                 sa.insert(table).values(
                     [{"check_type": check_type.name, "check_item": key,


### PR DESCRIPTION
datetime.utcnow() produce timezoneless timetag that breaks healtcheck and Grafana dashboards.
Replacing with datatime.now(timezone.utc)