### PR TITLE
281. AFC Engine facelift

### DIFF
--- a/src/afc-engine/AfcManager.cpp
+++ b/src/afc-engine/AfcManager.cpp
@@ -7628,7 +7628,7 @@ void AfcManager::compute()
 
 	// initialize all channels to max EIRP before computing
 	for (auto& channel : _channelList) {
-		for(int freqSegIdx=0; freqSegIdx<channel.segList.size(); ++freqSegIdx) {
+		for(int freqSegIdx=0; (size_t)freqSegIdx<channel.segList.size(); ++freqSegIdx) {
 			double segEIRP;
 			if (channel.type == INQUIRED_FREQUENCY) {
 				segEIRP = _inquiredFrequencyMaxPSD_dBmPerMHz + 10.0*log10((double) channel.bandwidth(freqSegIdx));
@@ -8339,7 +8339,7 @@ void AfcManager::runPointAnalysis()
 					int chanIdx;
 					for (chanIdx = 0; chanIdx < (int) _channelList.size(); ++chanIdx) {
 						ChannelStruct *channel = &(_channelList[chanIdx]);
-						for(int freqSegIdx=0; freqSegIdx<channel->segList.size(); ++freqSegIdx) {
+						for(int freqSegIdx=0; (size_t)freqSegIdx<channel->segList.size(); ++freqSegIdx) {
 							if (std::get<2>(channel->segList[freqSegIdx]) != BLACK) {
 								double chanStartFreq = channel->freqMHzList[freqSegIdx]*1.0e6;
 								double chanStopFreq = channel->freqMHzList[freqSegIdx+1]* 1.0e6;
@@ -8565,7 +8565,7 @@ void AfcManager::runPointAnalysis()
 							ChannelStruct *channel = &(_channelList[chanIdx]);
 							ChannelType channelType = channel->type;
 							bool useACI = (channelType == INQUIRED_FREQUENCY ? false : _aciFlag);
-							for(int freqSegIdx=0; freqSegIdx<channel->segList.size(); ++freqSegIdx) {
+							for(int freqSegIdx=0; (size_t)freqSegIdx<channel->segList.size(); ++freqSegIdx) {
 								ChannelColor chanColor = std::get<2>(channel->segList[freqSegIdx]);
 								if ( (chanColor != BLACK) ) {
 									double chanStartFreq = channel->freqMHzList[freqSegIdx] * 1.0e6;
@@ -9170,7 +9170,7 @@ void AfcManager::runPointAnalysis()
 
 										if (state == 0) {
 											freqSegIdx++;
-											if (freqSegIdx == channel->segList.size()) {
+											if ((size_t)freqSegIdx == channel->segList.size()) {
 												std::string txClutterStr;
 												std::string rxClutterStr;
 												std::string pathLossModelStr;
@@ -9253,7 +9253,7 @@ void AfcManager::runPointAnalysis()
 											}
 										} else {
 											itmSegIdx++;
-											if (itmSegIdx == itmSegList.size()) {
+											if ((size_t)itmSegIdx == itmSegList.size()) {
 												contFlag = false;
 											}
 										}
@@ -9631,7 +9631,7 @@ void AfcManager::runPointAnalysis()
 	int chanIdx;
 	for (chanIdx = 0; chanIdx < (int) _channelList.size(); ++chanIdx) {
 		ChannelStruct *channel = &(_channelList[chanIdx]);
-		for(int freqSegIdx=0; freqSegIdx<channel->segList.size(); ++freqSegIdx) {
+		for(int freqSegIdx=0; (size_t)freqSegIdx<channel->segList.size(); ++freqSegIdx) {
 			ChannelColor chanColor = std::get<2>(channel->segList[freqSegIdx]);
 			if ( (channel->type == ChannelType::INQUIRED_CHANNEL) && (chanColor != BLACK) && (chanColor != RED) ) {
 				double chanEirpLimit = std::min(std::get<0>(channel->segList[freqSegIdx]), std::get<1>(channel->segList[freqSegIdx]));
@@ -10221,7 +10221,7 @@ void AfcManager::runScanAnalysis()
 			/* Initialize eirpLimit_dBm to _maxEIRP_dBm for all channels                          */
 			/**************************************************************************************/
 			for (auto& channel : _channelList) {
-				for(int freqSegIdx=0; freqSegIdx<channel.segList.size(); ++freqSegIdx) {
+				for(int freqSegIdx=0; (size_t)freqSegIdx<channel.segList.size(); ++freqSegIdx) {
 					channel.segList[freqSegIdx] = std::make_tuple(_maxEIRP_dBm, _maxEIRP_dBm, GREEN);
 				}
 			}
@@ -10234,7 +10234,7 @@ void AfcManager::runScanAnalysis()
 				DeniedRegionClass *dr = _deniedRegionList[drIdx];
 				if (dr->intersect(rlanCoord.longitudeDeg, rlanCoord.latitudeDeg, 0.0, rlanHtAboveTerrain)) {
 					for (auto& channel : _channelList) {
-						for(int freqSegIdx=0; freqSegIdx<channel.segList.size(); ++freqSegIdx) {
+						for(int freqSegIdx=0; (size_t)freqSegIdx<channel.segList.size(); ++freqSegIdx) {
 							if (std::get<2>(channel.segList[freqSegIdx]) != BLACK) {
 								double chanStartFreq = channel.freqMHzList[freqSegIdx]*1.0e6;
 								double chanStopFreq = channel.freqMHzList[freqSegIdx+1]* 1.0e6;
@@ -10301,7 +10301,7 @@ void AfcManager::runScanAnalysis()
 					/**************************************************************************************/
 
 					for (auto& channel : _channelList) {
-						for(int freqSegIdx=0; freqSegIdx<channel.segList.size(); ++freqSegIdx) {
+						for(int freqSegIdx=0; (size_t)freqSegIdx<channel.segList.size(); ++freqSegIdx) {
 							if (std::get<2>(channel.segList[freqSegIdx]) != BLACK) {
 								double chanStartFreq = channel.freqMHzList[freqSegIdx]*1.0e6;
 								double chanStopFreq = channel.freqMHzList[freqSegIdx+1]* 1.0e6;
@@ -10384,7 +10384,7 @@ void AfcManager::runScanAnalysis()
 			}
 
 			for (auto& channel : _channelList) {
-				for(int freqSegIdx=0; freqSegIdx<channel.segList.size(); ++freqSegIdx) {
+				for(int freqSegIdx=0; (size_t)freqSegIdx<channel.segList.size(); ++freqSegIdx) {
 					if (channel.type == ChannelType::INQUIRED_CHANNEL) {
 						bwIdx = bw_index_map[channel.bandwidth(freqSegIdx)];
 						double channelEirp = std::min(std::get<0>(channel.segList[freqSegIdx]), std::get<1>(channel.segList[freqSegIdx]));
@@ -11143,7 +11143,7 @@ void AfcManager::runHeatmapAnalysis()
 	double chanStartFreq = channel->freqMHzList[freqSegIdx]*1.0e6;
 	double chanStopFreq = channel->freqMHzList[freqSegIdx+1]* 1.0e6;
 	double chanCenterFreq = (chanStartFreq + chanStopFreq)/2;
-	double chanBandwidth  = chanStopFreq - chanStartFreq;
+	// double chanBandwidth  = chanStopFreq - chanStartFreq;
 	bool useACI = (channel->type == INQUIRED_FREQUENCY ? false : _aciFlag);
 	CConst::SpectralAlgorithmEnum spectralAlgorithm = (channel->type == INQUIRED_FREQUENCY ? CConst::psdSpectralAlgorithm : _channelResponseAlgorithm);
 
@@ -11386,7 +11386,7 @@ void AfcManager::runHeatmapAnalysis()
 						} else if (distKmSquared < maxRadiusKmSquared) {
 
 							double ulsRxHeightAGL  = (segIdx == numPR ? (divIdx == 0 ? uls->getRxHeightAboveTerrain() : uls->getDiversityHeightAboveTerrain()) : uls->getPR(segIdx).heightAboveTerrainRx);
-							double ulsRxHeightAMSL = (segIdx == numPR ? (divIdx == 0 ? uls->getRxHeightAMSL() : uls->getDiversityHeightAMSL()) : uls->getPR(segIdx).heightAMSLRx);
+							// double ulsRxHeightAMSL = (segIdx == numPR ? (divIdx == 0 ? uls->getRxHeightAMSL() : uls->getDiversityHeightAMSL()) : uls->getPR(segIdx).heightAMSLRx);
 							double ulsSegmentDistance = (segIdx == numPR ? uls->getLinkDistance() : uls->getPR(segIdx).segmentDistance);
 
 							/**************************************************************************************/
@@ -11411,7 +11411,7 @@ void AfcManager::runHeatmapAnalysis()
 							}
 							/**************************************************************************************/
 
-							Vector3 ulsAntennaPointing = (segIdx == numPR ? (divIdx == 0 ? uls->getAntennaPointing() : uls->getDiversityAntennaPointing()) : uls->getPR(segIdx).pointing);
+							// Vector3 ulsAntennaPointing = (segIdx == numPR ? (divIdx == 0 ? uls->getAntennaPointing() : uls->getDiversityAntennaPointing()) : uls->getPR(segIdx).pointing);
 
 							// Use Haversine formula with average earth radius of 6371 km
 							double groundDistanceKm;
@@ -11489,8 +11489,8 @@ void AfcManager::runHeatmapAnalysis()
 									double angleOffBoresightDeg;
 									double rxPowerDBW;
 									double I2NDB;
-									double marginDB;
-									double eirpLimit_dBm;
+									// double marginDB;
+									// double eirpLimit_dBm;
 									double nearFieldOffsetDB;
 									double nearField_xdb;
 									double nearField_u;
@@ -11560,7 +11560,7 @@ void AfcManager::runHeatmapAnalysis()
 										double d2;
 										double pathDifference;
 										double fresnelIndex = -1.0;
-										double ulsLinkDistance = uls->getLinkDistance();
+										// double ulsLinkDistance = uls->getLinkDistance();
 										double ulsWavelength = CConst::c / ((uls->getStartFreq() + uls->getStopFreq()) / 2);
 										if (ulsSegmentDistance != -1.0) {
 											const Vector3 ulsTxPos = (segIdx ? uls->getPR(segIdx-1).positionTx : uls->getTxPosition());
@@ -12635,7 +12635,7 @@ void AfcManager::computeInquiredFreqRangesPSD(std::vector<psdFreqRangeClass> &ps
 	for(auto& channel : _channelList) {
 		if (channel.type == INQUIRED_FREQUENCY) {
 			psdFreqRangeClass psdFreqRange;
-			for(int freqSegIdx=0; freqSegIdx<channel.segList.size(); ++freqSegIdx) {
+			for(int freqSegIdx=0; (size_t)freqSegIdx<channel.segList.size(); ++freqSegIdx) {
 				if (freqSegIdx == 0) {
 					psdFreqRange.freqMHzList.push_back(channel.freqMHzList[0]);
 				}
@@ -12748,17 +12748,17 @@ void AfcManager::createChannelList()
 
 				int idxA = 0;
 				bool overlapA;
-				while ((idxA < freqSegmentList.size())&&(startFreq > freqSegmentList[idxA].second)) {
+				while (((size_t)idxA < freqSegmentList.size())&&(startFreq > freqSegmentList[idxA].second)) {
 					idxA++;
 				}
-				overlapA = ((idxA < freqSegmentList.size()) && (startFreq >= freqSegmentList[idxA].first));
+				overlapA = (((size_t)idxA < freqSegmentList.size()) && (startFreq >= freqSegmentList[idxA].first));
 
 				int idxB = 0;
 				bool overlapB;
-				while ((idxB < freqSegmentList.size())&&(stopFreq > freqSegmentList[idxB].second)) {
+				while (((size_t)idxB < freqSegmentList.size())&&(stopFreq > freqSegmentList[idxB].second)) {
 					idxB++;
 				}
-				overlapB = ((idxB < freqSegmentList.size()) && (stopFreq >= freqSegmentList[idxB].first));
+				overlapB = (((size_t)idxB < freqSegmentList.size()) && (stopFreq >= freqSegmentList[idxB].first));
 
 				int start = overlapA ? freqSegmentList[idxA].first  : startFreq;
 				int stop  = overlapB ? freqSegmentList[idxB].second : stopFreq;
@@ -12912,7 +12912,7 @@ void AfcManager::splitFrequencyRanges()
 		ChannelStruct *channel = &(_channelList[chanIdx]);
 		if (channel->type == INQUIRED_FREQUENCY) {
 			int segIdx = 0;
-			while(segIdx<channel->segList.size()) {
+			while((size_t)segIdx<channel->segList.size()) {
 				ChannelColor segColor = std::get<2>(channel->segList[segIdx]);
 				if (segColor != BLACK) {
 					int chanStartFreqMHz = channel->freqMHzList[segIdx];

--- a/src/afc-engine/cconst.cpp
+++ b/src/afc-engine/cconst.cpp
@@ -89,6 +89,7 @@ const StrTypeClass CConst::strPropEnvMethodList[] = {{CConst::nlcdPointPropEnvMe
 						     {CConst::urbanPropEnvMethod, "Urban"},
 						     {CConst::suburbanPropEnvMethod, "Suburban"},
 						     {CConst::ruralPropEnvMethod, "Rural"},
+						     {CConst::unknownPropEnvMethod, "Unknown"},
 						     {-1, (char *)0}};
 
 const StrTypeClass CConst::strULSAntennaTypeList[] = {{CConst::F1336OmniAntennaType, "F.1336 Omni"},
@@ -97,6 +98,9 @@ const StrTypeClass CConst::strULSAntennaTypeList[] = {{CConst::F1336OmniAntennaT
 						      {CConst::R2AIP07AntennaType, "WINNF-AIP-07"},
 						      {CConst::R2AIP07CANAntennaType,
 						       "WINNF-AIP-07-CAN"},
+						      {CConst::OmniAntennaType, "Omni"},
+						      {CConst::LUTAntennaType, "LUT"},
+						      {CConst::UnknownAntennaType, "Unknown"},
 						      {-1, (char *)0}};
 
 const StrTypeClass CConst::strHeightSourceList[] = {{CConst::unknownHeightSource, "UNKNOWN"},
@@ -113,6 +117,7 @@ const StrTypeClass CConst::strSpectralAlgorithmList[] = {{CConst::pwrSpectralAlg
 
 const StrTypeClass CConst::strPRTypeList[] = {{CConst::backToBackAntennaPRType, "Ant"},
 					      {CConst::billboardReflectorPRType, "Ref"},
+					      {CConst::unknownPRType, "Unknown"},
 					      {-1, (char *)0}};
 
 const StrTypeClass CConst::strAntennaCategoryList[] = {{CConst::HPAntennaCategory, "HP"},

--- a/src/afc-engine/polygon.cpp
+++ b/src/afc-engine/polygon.cpp
@@ -1017,7 +1017,7 @@ PolygonClass *PolygonClass::combinePolygons(std::vector<PolygonClass *> polyList
 	PolygonClass *combinedPoly = new PolygonClass();
 
 	int totalNumSegment = 0;
-	for (int polyIdx = 0; polyIdx < polyList.size(); ++polyIdx) {
+	for (int polyIdx = 0; (size_t)polyIdx < polyList.size(); ++polyIdx) {
 		totalNumSegment += polyList[polyIdx]->num_segment;
 	}
 
@@ -1028,7 +1028,7 @@ PolygonClass *PolygonClass::combinePolygons(std::vector<PolygonClass *> polyList
 	combinedPoly->bdy_pt_y = (int **)malloc(totalNumSegment * sizeof(int *));
 
 	int segIdx = 0;
-	for (int polyIdx = 0; polyIdx < polyList.size(); ++polyIdx) {
+	for (int polyIdx = 0; (size_t)polyIdx < polyList.size(); ++polyIdx) {
 		PolygonClass *poly = polyList[polyIdx];
 		for (int segment_idx = 0; segment_idx <= poly->num_segment - 1; segment_idx++) {
 			int numPt = poly->num_bdy_pt[segment_idx];


### PR DESCRIPTION
- AfcEngine.cpp:
  - Signed/unsigned comparisons (mainly iteration over vectrors with integer indices) explicitly casted to size_t
  - Unused variables commented out
- polygon.cpp: Signed/unsigned comparisons (iteration vectrors with integer indices) explicitly casted to size_t
- cconst.cpp: Missing names for enum values added

Closes #281 