### PR TITLE
348. Add index for month_idx columns of all ALS database tables

### DIFF
--- a/als/ALS.sql
+++ b/als/ALS.sql
@@ -193,17 +193,27 @@ CREATE INDEX ON "afc_message" ("ap_ip");
 
 CREATE INDEX ON "afc_message" ("runtime_opt");
 
+CREATE INDEX ON "afc_message" ("month_idx");
+
 CREATE INDEX ON "rx_envelope" USING HASH ("rx_envelope_digest");
+
+CREATE INDEX ON "rx_envelope" ("month_idx");
 
 CREATE INDEX ON "tx_envelope" USING HASH ("tx_envelope_digest");
 
+CREATE INDEX ON "tx_envelope" ("month_idx");
+
 CREATE INDEX ON "mtls_dn" USING HASH ("dn_text_digest");
+
+CREATE INDEX ON "mtls_dn" ("month_idx");
 
 CREATE INDEX ON "request_response_in_message" ("request_id");
 
 CREATE INDEX ON "request_response_in_message" ("request_response_digest");
 
 CREATE INDEX ON "request_response_in_message" ("expire_time");
+
+CREATE INDEX ON "request_response_in_message" ("month_idx");
 
 CREATE INDEX ON "request_response" USING HASH ("request_response_digest");
 
@@ -221,11 +231,15 @@ CREATE INDEX ON "request_response" ("response_description");
 
 CREATE INDEX ON "request_response" ("response_data");
 
+CREATE INDEX ON "request_response" ("month_idx");
+
 CREATE INDEX ON "device_descriptor" USING HASH ("device_descriptor_digest");
 
 CREATE INDEX ON "device_descriptor" ("serial_number");
 
 CREATE INDEX ON "device_descriptor" ("certifications_digest");
+
+CREATE INDEX ON "device_descriptor" ("month_idx");
 
 CREATE INDEX ON "certification" USING HASH ("certifications_digest");
 
@@ -233,9 +247,15 @@ CREATE INDEX ON "certification" ("ruleset_id");
 
 CREATE INDEX ON "certification" ("certification_id");
 
+CREATE INDEX ON "certification" ("month_idx");
+
 CREATE INDEX ON "compressed_json" USING HASH ("compressed_json_digest");
 
+CREATE INDEX ON "compressed_json" ("month_idx");
+
 CREATE INDEX ON "customer" ("customer_name");
+
+CREATE INDEX ON "customer" ("month_idx");
 
 CREATE INDEX ON "location" USING HASH ("location_digest");
 
@@ -247,15 +267,23 @@ CREATE INDEX ON "location" ("height_m");
 
 CREATE INDEX ON "location" ("height_type");
 
+CREATE INDEX ON "location" ("month_idx");
+
 CREATE INDEX ON "afc_config" USING HASH ("afc_config_text_digest");
+
+CREATE INDEX ON "afc_config" ("month_idx");
 
 CREATE UNIQUE INDEX ON "geo_data_version" ("geo_data_version", "month_idx");
 
 CREATE INDEX ON "geo_data_version" ("geo_data_version");
 
+CREATE INDEX ON "geo_data_version" ("month_idx");
+
 CREATE UNIQUE INDEX ON "uls_data_version" ("uls_data_version", "month_idx");
 
 CREATE INDEX ON "uls_data_version" ("uls_data_version");
+
+CREATE INDEX ON "uls_data_version" ("month_idx");
 
 CREATE INDEX ON "max_psd" USING HASH ("request_response_digest");
 
@@ -265,6 +293,8 @@ CREATE INDEX ON "max_psd" ("high_frequency_mhz");
 
 CREATE INDEX ON "max_psd" ("max_psd_dbm_mhz");
 
+CREATE INDEX ON "max_psd" ("month_idx");
+
 CREATE INDEX ON "max_eirp" USING HASH ("request_response_digest");
 
 CREATE INDEX ON "max_eirp" ("op_class");
@@ -273,9 +303,17 @@ CREATE INDEX ON "max_eirp" ("channel");
 
 CREATE INDEX ON "max_eirp" ("max_eirp_dbm");
 
+CREATE INDEX ON "max_eirp" ("month_idx");
+
 CREATE UNIQUE INDEX ON "afc_server" ("afc_server_name", "month_idx");
 
 CREATE INDEX ON "afc_server" ("afc_server_name");
+
+CREATE INDEX ON "afc_server" ("month_idx");
+
+CREATE INDEX ON "decode_error" ("time");
+
+CREATE INDEX ON "decode_error" ("month_idx");
 
 COMMENT ON TABLE "afc_message" IS 'AFC Request/Response message pair (contain individual requests/responses)';
 

--- a/als/als_db_schema/ALS.dbml
+++ b/als/als_db_schema/ALS.dbml
@@ -32,13 +32,15 @@ table afc_message [headercolor: #000000, note: 'AFC Request/Response message pai
     dn_text_digest [type: hash]
     ap_ip
     runtime_opt
+    month_idx
   }
 }
 
 Ref afc_message_afc_server_ref: afc_message.(afc_server, month_idx) > afc_server.(afc_server_id, month_idx)
 Ref afc_message_rx_envelope_digest_ref: afc_message.(rx_envelope_digest, month_idx) > rx_envelope.(rx_envelope_digest, month_idx)
 Ref afc_message_tx_envelope_digest_ref: afc_message.(tx_envelope_digest, month_idx) > tx_envelope.(tx_envelope_digest, month_idx)
-Ref afc_message_dn_text_digest_ref: afc_message.(dn_text_digest, month_idx) > mtls_dn.(dn_text_digest, month_idx) [note: 'This relation was added to existing database, so it is OK for dn_text_digest to be NULL on legacy records']
+// This relation was added to existing database, so it is OK for dn_text_digest to be NULL on legacy records
+Ref afc_message_dn_text_digest_ref: afc_message.(dn_text_digest, month_idx) > mtls_dn.(dn_text_digest, month_idx)
 
 // Outer part of request message
 table rx_envelope [headercolor: #4B82B0, note: 'Envelope (constant part) of AFC Request Message'] {
@@ -49,6 +51,7 @@ table rx_envelope [headercolor: #4B82B0, note: 'Envelope (constant part) of AFC 
   indexes {
     (rx_envelope_digest, month_idx) [pk]
     rx_envelope_digest [type: hash]
+    month_idx
   }
 }
 
@@ -61,6 +64,7 @@ table tx_envelope [headercolor: #4B82B0, note: 'Envelope (constant part) of AFC 
   indexes {
     (tx_envelope_digest, month_idx) [pk]
     tx_envelope_digest [type: hash]
+    month_idx
   }
 }
 
@@ -74,6 +78,7 @@ table mtls_dn [headercolor: #4B82B0, note: 'mTLS certificate DN components'] {
   indexes {
     (dn_text_digest, month_idx) [pk]
     dn_text_digest [type: hash]
+    month_idx
   }
 }
 
@@ -91,6 +96,7 @@ table request_response_in_message [headercolor: #4B82B0, note: 'Associative tabl
     request_id
     request_response_digest
     expire_time
+    month_idx
   }
 }
 
@@ -123,6 +129,7 @@ table request_response [headercolor: #2D6512, note: 'Potentiially constant part 
     response_code
     response_description
     response_data
+    month_idx
   }
 }
 
@@ -147,6 +154,7 @@ table device_descriptor [headercolor: #2D6512, note: 'Information about device (
     device_descriptor_digest [type: hash]
     serial_number
     certifications_digest
+    month_idx
   }
 }
 
@@ -165,6 +173,7 @@ table certification [headercolor: #79AD51, note: 'Element of certifications list
     certifications_digest [type: hash]
     ruleset_id
     certification_id
+    month_idx
   }
 }
 
@@ -177,6 +186,7 @@ table compressed_json [headercolor: #2D6512, note: 'Compressed body of request o
   indexes {
     (compressed_json_digest, month_idx) [pk]
     compressed_json_digest [type: hash]
+    month_idx
   }
 }
 
@@ -189,6 +199,7 @@ table customer [headercolor: #79AD51, note: 'Customer aka vendor aka user'] {
   indexes {
     (customer_id, month_idx) [pk]
     customer_name
+    month_idx
   }
 }
 
@@ -211,6 +222,7 @@ table location [headercolor: #2D6512, note: 'AP location'] {
     location_type
     height_m
     height_type
+    month_idx
   }
 }
 
@@ -224,6 +236,7 @@ table afc_config [headercolor: #79AD51, note: 'AFC Config'] {
   indexes {
     (afc_config_text_digest, month_idx) [pk]
     afc_config_text_digest [type: hash]
+    month_idx
   }
 }
 
@@ -237,6 +250,7 @@ table geo_data_version [headercolor: #79AD51, note: 'Version of geospatial data'
     (geo_data_version_id, month_idx) [pk]
     (geo_data_version, month_idx) [unique]
     geo_data_version
+    month_idx
   }
 }
 
@@ -250,6 +264,7 @@ table uls_data_version [headercolor: #79AD51, note: 'Version of ULS data'] {
     (uls_data_version_id, month_idx) [pk]
     (uls_data_version, month_idx) [unique]
     uls_data_version
+    month_idx
   }
 }
 
@@ -267,6 +282,7 @@ table max_psd [headercolor: #990D0D, note: 'PSD result'] {
     low_frequency_mhz
     high_frequency_mhz
     max_psd_dbm_mhz
+    month_idx
   }
 }
 
@@ -286,6 +302,7 @@ table max_eirp [headercolor: #990D0D, note: 'EIRP result'] {
     op_class
     channel
     max_eirp_dbm
+    month_idx
   }
 }
 
@@ -301,6 +318,7 @@ table afc_server [headercolor: #4B82B0] {
     (afc_server_id, month_idx) [pk]
     (afc_server_name, month_idx) [unique]
     afc_server_name
+    month_idx
   }
 }
 
@@ -312,4 +330,9 @@ table decode_error {
   code_line integer
   data text
   month_idx smallint
+
+  indexes {
+    time
+    month_idx
+  }
 }

--- a/als/als_db_schema/ALS_raw.sql
+++ b/als/als_db_schema/ALS_raw.sql
@@ -174,17 +174,27 @@ CREATE INDEX ON "afc_message" ("ap_ip");
 
 CREATE INDEX ON "afc_message" ("runtime_opt");
 
+CREATE INDEX ON "afc_message" ("month_idx");
+
 CREATE INDEX ON "rx_envelope" USING HASH ("rx_envelope_digest");
+
+CREATE INDEX ON "rx_envelope" ("month_idx");
 
 CREATE INDEX ON "tx_envelope" USING HASH ("tx_envelope_digest");
 
+CREATE INDEX ON "tx_envelope" ("month_idx");
+
 CREATE INDEX ON "mtls_dn" USING HASH ("dn_text_digest");
+
+CREATE INDEX ON "mtls_dn" ("month_idx");
 
 CREATE INDEX ON "request_response_in_message" ("request_id");
 
 CREATE INDEX ON "request_response_in_message" ("request_response_digest");
 
 CREATE INDEX ON "request_response_in_message" ("expire_time");
+
+CREATE INDEX ON "request_response_in_message" ("month_idx");
 
 CREATE INDEX ON "request_response" USING HASH ("request_response_digest");
 
@@ -202,11 +212,15 @@ CREATE INDEX ON "request_response" ("response_description");
 
 CREATE INDEX ON "request_response" ("response_data");
 
+CREATE INDEX ON "request_response" ("month_idx");
+
 CREATE INDEX ON "device_descriptor" USING HASH ("device_descriptor_digest");
 
 CREATE INDEX ON "device_descriptor" ("serial_number");
 
 CREATE INDEX ON "device_descriptor" ("certifications_digest");
+
+CREATE INDEX ON "device_descriptor" ("month_idx");
 
 CREATE INDEX ON "certification" USING HASH ("certifications_digest");
 
@@ -214,9 +228,15 @@ CREATE INDEX ON "certification" ("ruleset_id");
 
 CREATE INDEX ON "certification" ("certification_id");
 
+CREATE INDEX ON "certification" ("month_idx");
+
 CREATE INDEX ON "compressed_json" USING HASH ("compressed_json_digest");
 
+CREATE INDEX ON "compressed_json" ("month_idx");
+
 CREATE INDEX ON "customer" ("customer_name");
+
+CREATE INDEX ON "customer" ("month_idx");
 
 CREATE INDEX ON "location" USING HASH ("location_digest");
 
@@ -228,15 +248,23 @@ CREATE INDEX ON "location" ("height_m");
 
 CREATE INDEX ON "location" ("height_type");
 
+CREATE INDEX ON "location" ("month_idx");
+
 CREATE INDEX ON "afc_config" USING HASH ("afc_config_text_digest");
+
+CREATE INDEX ON "afc_config" ("month_idx");
 
 CREATE UNIQUE INDEX ON "geo_data_version" ("geo_data_version", "month_idx");
 
 CREATE INDEX ON "geo_data_version" ("geo_data_version");
 
+CREATE INDEX ON "geo_data_version" ("month_idx");
+
 CREATE UNIQUE INDEX ON "uls_data_version" ("uls_data_version", "month_idx");
 
 CREATE INDEX ON "uls_data_version" ("uls_data_version");
+
+CREATE INDEX ON "uls_data_version" ("month_idx");
 
 CREATE INDEX ON "max_psd" USING HASH ("request_response_digest");
 
@@ -246,6 +274,8 @@ CREATE INDEX ON "max_psd" ("high_frequency_mhz");
 
 CREATE INDEX ON "max_psd" ("max_psd_dbm_mhz");
 
+CREATE INDEX ON "max_psd" ("month_idx");
+
 CREATE INDEX ON "max_eirp" USING HASH ("request_response_digest");
 
 CREATE INDEX ON "max_eirp" ("op_class");
@@ -254,9 +284,17 @@ CREATE INDEX ON "max_eirp" ("channel");
 
 CREATE INDEX ON "max_eirp" ("max_eirp_dbm");
 
+CREATE INDEX ON "max_eirp" ("month_idx");
+
 CREATE UNIQUE INDEX ON "afc_server" ("afc_server_name", "month_idx");
 
 CREATE INDEX ON "afc_server" ("afc_server_name");
+
+CREATE INDEX ON "afc_server" ("month_idx");
+
+CREATE INDEX ON "decode_error" ("time");
+
+CREATE INDEX ON "decode_error" ("month_idx");
 
 COMMENT ON TABLE "afc_message" IS 'AFC Request/Response message pair (contain individual requests/responses)';
 

--- a/als/als_migrations/versions/2025_04_29-31179a635942_add_index_for_month_idx_columns.py
+++ b/als/als_migrations/versions/2025_04_29-31179a635942_add_index_for_month_idx_columns.py
@@ -35,6 +35,7 @@ TABLES = [
     "afc_server",
     "decode_error"]
 
+
 def upgrade() -> None:
     """ Add index on 'month_idx' column to all tables """
     for table in TABLES:

--- a/als/als_migrations/versions/2025_04_29-31179a635942_add_index_for_month_idx_columns.py
+++ b/als/als_migrations/versions/2025_04_29-31179a635942_add_index_for_month_idx_columns.py
@@ -1,0 +1,50 @@
+"""Add index for month_idx columns
+
+Revision ID: 31179a635942
+Revises: cc1c9db1c90d
+Create Date: 2025-04-29 07:43:29.001027
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '31179a635942'
+down_revision = 'cc1c9db1c90d'
+branch_labels = None
+depends_on = None
+
+TABLES = [
+    "afc_message",
+    "rx_envelope",
+    "tx_envelope",
+    "mtls_dn",
+    "request_response_in_message",
+    "request_response",
+    "device_descriptor",
+    "certification",
+    "compressed_json",
+    "customer",
+    "location",
+    "afc_config",
+    "geo_data_version",
+    "uls_data_version",
+    "max_psd",
+    "max_eirp",
+    "afc_server",
+    "decode_error"]
+
+def upgrade() -> None:
+    """ Add index on 'month_idx' column to all tables """
+    for table in TABLES:
+        op.create_index(index_name=f"{table}_month_idx_idx",
+                        table_name=table, columns=["month_idx"],
+                        if_not_exists=True)
+
+
+def downgrade() -> None:
+    """ Remove index on 'month_idx' column from all tables """
+    for table in TABLES:
+        op.drop_index(index_name=f"{table}_month_idx_idx", table_name=table,
+                      if_exists=True)

--- a/als/als_migrations/versions/2025_04_29-31179a635942_add_index_for_month_idx_columns.py
+++ b/als/als_migrations/versions/2025_04_29-31179a635942_add_index_for_month_idx_columns.py
@@ -42,6 +42,9 @@ def upgrade() -> None:
         op.create_index(index_name=f"{table}_month_idx_idx",
                         table_name=table, columns=["month_idx"],
                         if_not_exists=True)
+    op.create_index(index_name="decode_error_time_idx",
+                    table_name="decode_error", columns=["time"],
+                    if_not_exists=True)
 
 
 def downgrade() -> None:
@@ -49,3 +52,5 @@ def downgrade() -> None:
     for table in TABLES:
         op.drop_index(index_name=f"{table}_month_idx_idx", table_name=table,
                       if_exists=True)
+    op.drop_index(index_name="decode_error_time_idx",
+                  table_name="decode_error", if_exists=True)


### PR DESCRIPTION
month_idx column will be used in ALS tables' partitioning, it requires its own index

Closes #348