### PR TITLE
350. Fixing rat database upgrade bug

### DIFF
--- a/rat_server/entrypoint.sh
+++ b/rat_server/entrypoint.sh
@@ -27,6 +27,7 @@ esac
 
 
 rat-manage-api db-create --if_absent
+rat-manage-api db-upgrade
 
 postfix start &
 exec gunicorn \

--- a/src/ratapi/ratapi/manage.py
+++ b/src/ratapi/ratapi/manage.py
@@ -1766,7 +1766,7 @@ def main():
     @click.option('--log-level', help='Console logging lowest level displayed.')
     @with_appcontext
     def db_upgrade(log_level):
-        DbUpgrade()(flaskapp=flask.current_app)()
+        DbUpgrade()(flaskapp=flask.current_app)
 
     try:
         cli()

--- a/src/ratapi/ratapi/migrations/versions/9fba1618496f_downloaded_field_added_to_cert_id_table.py
+++ b/src/ratapi/ratapi/migrations/versions/9fba1618496f_downloaded_field_added_to_cert_id_table.py
@@ -18,7 +18,7 @@ def upgrade():
     op.add_column(
         'cert_id',
         sa.Column('downloaded', sa.Boolean(), nullable=False,
-                  server_defafult=sa.sql.expression.false()))
+                  server_default=sa.sql.expression.false()))
 
 
 def downgrade():


### PR DESCRIPTION
- 9fba1618496f_downloaded_field_added_to_cert_id_table.py - typo fixed, now upgrade works as expected
- manage.py - typo fixed. Now rat-manage-api db-upgrade doesn't crash upon completion
- entrypoint.sh - alembic upgrade enforced on startup

Closes #350