### PR TITLE
358. Indoor/outdoor certificate handling change

### DIFF
--- a/afc_server/afc_server_db.py
+++ b/afc_server/afc_server_db.py
@@ -110,12 +110,7 @@ class AfcCertResp:
             explanation="certificate denied"),
          DenyCriterion(
             predicate=lambda cr: getattr(cr, "serial_denied"),
-            explanation="AP serial number denied"),
-         DenyCriterion(
-            predicate=lambda cr:
-                ((getattr(cr, "location_flags") or 0) &
-                 hardcoded_relations.CERT_ID_LOCATION_OUTDOOR) == 0,
-            explanation="outdoor operation not allowed")]
+            explanation="AP serial number denied")]
 
     def __init__(self, bypass_checks: Optional[AfcCertReq] = None) -> None:
         """Constructor

--- a/src/ratapi/ratapi/manage.py
+++ b/src/ratapi/ratapi/manage.py
@@ -944,7 +944,8 @@ class CertIdSweep:
                             if code == 103:
                                 location = CERT_ID_LOCATION_OUTDOOR
                             elif code == 111:
-                                location = CERT_ID_LOCATION_INDOOR
+                                location = CERT_ID_LOCATION_INDOOR | \
+                                    CERT_ID_LOCATION_OUTDOOR
                             else:
                                 location = CERT_ID_LOCATION_UNKNOWN
                             if not location == CERT_ID_LOCATION_UNKNOWN:
@@ -1026,7 +1027,7 @@ class CertIdSweep:
                                            for note_info in
                                            spec_info.get('lNotes', {}).
                                            get('notes', [])):
-                                        location = CERT_ID_LOCATION_INDOOR
+                                        location |= CERT_ID_LOCATION_INDOOR
                                         break
                                 cert = CertId.query.filter_by(
                                     certification_id=fcc_id).first()

--- a/src/ratapi/ratapi/views/ratafc.py
+++ b/src/ratapi/ratapi/views/ratafc.py
@@ -452,9 +452,7 @@ class RatAfc(MethodView):
                          self.__class__, inspect.stack()[0][3],
                          certId.certification_id)
 
-        if not certId.location & CERT_ID_LOCATION_OUTDOOR:
-            raise DeviceUnallowedException("Outdoor operation not allowed")
-        elif certId.location & CERT_ID_LOCATION_INDOOR:
+        if certId.location & CERT_ID_LOCATION_INDOOR:
             indoor_certified = True
         else:
             indoor_certified = False


### PR DESCRIPTION
1. Layout of certificate flags in cert_id of ratdb reverted to original outdoor or indoor+outdoor. Actually only the preence of 'indoor' flag is important, but the very existence of outdoor flag makes it logical to use it with every certificate
2. afc_server and maghnd changed to not making any rejections based on indoor/outdoor certificate flags. They only convey indoor flag to AFC Engine

Checked with load tool that uses both indoor and outdoor certificates - no rejections.

Closes #358