### PR TITLE
356. Probe ratdb database on rat_server start

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,6 +56,7 @@ services:
 
   rat_server:
     image: ${PRIV_REPO:-ghcr.io/open-afc-project}/webui-image:${TAG:-latest}
+    restart: always
     volumes:
       - ${VOL_H_DB}:${VOL_C_DB}
       - ./pipe:/pipe

--- a/rat_server/entrypoint.sh
+++ b/rat_server/entrypoint.sh
@@ -26,8 +26,8 @@ case "$AFC_DEVEL_ENV" in
 esac
 
 
-rat-manage-api db-create --if_absent
-rat-manage-api db-upgrade
+rat-manage-api db-create --if_absent || exit 1
+rat-manage-api db-upgrade || exit 1
 
 postfix start &
 exec gunicorn \


### PR DESCRIPTION
If rat_server container starts before ratdb, it skips ratdb alembic upgrade procedure and proceeds with new code on old database structure.

To avoid this problem, failure of ratdb creation/upgrade on rat_server startup cause container termination.

To facilitate its restart (on the moment when ratdb server is, hopefully, ready), rat_server set to autorestart in docker-compose.yaml.

Tested by adding artificial delay before Postgres start in ratdb container. After couple of restarts rat_server starts normally when ratdb become available.

Closes #356