### PR TITLE
Replace deprecated pkg_resources with importlib

### DIFF
--- a/src/ratapi/ratapi/cmd_utils.py
+++ b/src/ratapi/ratapi/cmd_utils.py
@@ -15,9 +15,9 @@ def packageversion(pkg_name):
     :return: The version identifier or None.
     :rtype: str
     '''
-    import pkg_resources
+    from importlib.metadata import version
     try:
-        return pkg_resources.require(pkg_name)[0].version
+        return version(pkg_name)
     except Exception as err:
         LOGGER.error('Failed to fetch package %s version: %s', pkg_name, err)
         return None

--- a/src/ratapi/ratapi/views/ratafc.py
+++ b/src/ratapi/ratapi/views/ratafc.py
@@ -16,7 +16,6 @@ import logging
 import os
 import sys
 import shutil
-import pkg_resources
 import flask
 import json
 import glob

--- a/src/ratapi/ratapi/views/ratapi.py
+++ b/src/ratapi/ratapi/views/ratapi.py
@@ -13,7 +13,7 @@
 import logging
 import os
 import sys
-import pkg_resources
+import importlib.metadata
 import flask
 import json
 import glob
@@ -103,9 +103,9 @@ class GuiConfig(MethodView):
         # Figure out the current server version
         try:
             if sys.version_info.major != 3:
-                serververs = pkg_resources.require('ratapi')[0].version
+                serververs = importlib.metadata.version('ratapi')
             else:
-                serververs = pkg_resources.get_distribution('ratapi').version
+                serververs = importlib.metadata.distribution('ratapi').version
         except Exception as err:
             LOGGER.error('Failed to fetch server version: {0}'.format(err))
             serververs = 'unknown'


### PR DESCRIPTION
Calls to pkg_resources give a warning message after updates to setuptools.

Replaced calls with calls to importlib, the more modern way of getting package versions