### PR TITLE
Limit workflow concurrency to one job at a time

### DIFF
--- a/.github/workflows/regressions-test-remote-rkf.yml
+++ b/.github/workflows/regressions-test-remote-rkf.yml
@@ -16,6 +16,11 @@ on:
 permissions:
   id-token: write
 
+# limit to 1 job at a time, others will be queued
+concurrency:
+  group: remote-ci-rkf-server
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because the regression test job turns the server on and off, only one job can be allowed to run at a time even on different branches. Otherwise the first job to finish shuts down the server even when the later ones are not finished.