### PR TITLE
430: Updated ULS Downloader to process countries independently

### DIFF
--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,6 +1,6 @@
 # Release Note
 ## **Version and Date**
-|Version|**430*|
+|Version|**430**|
 | :- | :- |
 |**Date**|**07/07/2026**|
 

--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,5 +1,22 @@
 # Release Note
 ## **Version and Date**
+|Version|**430*|
+| :- | :- |
+|**Date**|**07/07/2026**|
+
+## **Issues Addressed**
+ * 430: Update ULS Downloader to process countries independently
+ * The issue was addressed by saving the latest error-free database (for both Countries X and Y) so that if the next download from Country X is erroneous, the latest error-free database of Country X plus the most current download of the Country Y are used.
+
+## **Interface Changes**
+ * None
+
+## **Testing Done**
+ * Tested by triggering a relevant error within each try catch, such as passing incorrect data through overwriting. 
+ * Tested by taking downloaded data from a successful run and modifying it to contain formatting errors to see if the process was able to handle a crash if the download was successful, but mistakes such as the | appearing occurred. 
+
+## **Open Issues** 
+
 |Version|**406*|
 | :- | :- |
 |**Date**|**11/11/2025**|

--- a/src/ratapi/ratapi/db/daily_uls_parse.py
+++ b/src/ratapi/ratapi/db/daily_uls_parse.py
@@ -144,6 +144,44 @@ def downloadFiles(region, logFile, currentWeekday, fullPathTempDir):
 
 # Downloads antenna files
 
+# Retrieves the most recent download from the passed region
+def getMostRecentRegionDownload(region, fullPathSaveDir):
+    regionSaveParentDir = os.path.join(fullPathSaveDir, region)
+
+    existingBackups = [
+        d for d in os.listdir(regionSaveParentDir) 
+        if os.path.isdir(os.path.join(regionSaveParentDir, d))
+    ]
+
+    if existingBackups:
+        existingBackups.sort()
+        
+        mostRecentName = existingBackups[-1]
+        mostRecentPath = os.path.join(regionSaveParentDir, mostRecentName)
+        return mostRecentPath
+    else:
+        return None
+    
+# Replaces the region data with the most recent backup found in the saved directory
+def replaceRegionDataWithLastSuccess(region, fullPathSaveDir, fullPathTempDir):
+    destDir = os.path.join(fullPathTempDir, region)
+
+    srcDir = getMostRecentRegionDownload(region, fullPathSaveDir)
+    if srcDir is None:
+        raise FileNotFoundError(f"Backup directory does not exist.")
+    if os.path.exists(destDir):
+        shutil.rmtree(destDir)
+    shutil.copytree(srcDir, destDir)
+
+# Handles a failure of a region, returning or crashing based on the passed flag
+def handleRegionFailure(region, regionFailureFlag, fullPathSaveDir, fullPathTempDir):
+    if not regionFailureFlag:
+        print(f"Attempting to replace the failed download of region: {region} with last success.")
+        replaceRegionDataWithLastSuccess(region, fullPathSaveDir, fullPathTempDir)
+        print(f"Replacement Successful.")
+        return True # Original Download has failed
+    else:
+        raise RuntimeError(f"Previously successful data has failed.")
 
 def prepareAFCGitHubFiles(rawDir, destDir, logFile):
     # Files in rawDir are downloaded from
@@ -475,7 +513,7 @@ def generateUlsScriptInputStatic(staticDataFile, logFile, genFilename):
 
 
 def storeDataIdentities(sqlFile, identityDict):
-    """ Stores region data identities in gewnerated SQLite database.
+    """ Stores region data identities in generated SQLite database.
     For FCC ULS identity is upload datetime, for Canada SMS, for now, sadly,
     only an MD5 of downloaded files.
 
@@ -509,6 +547,11 @@ def daily_uls_parse(state_root, interactive):
     nameTime += "_UniiUS" + uniiStr.replace(":", "")
 
     temp = "/temp"
+
+    save = "/country_history"
+
+    didCAFail = False
+    didUSFail = False
 
     root = state_root + "/daily_uls_parse"  # root so path is consisent
 
@@ -545,6 +588,9 @@ def daily_uls_parse(state_root, interactive):
     ###########################################################################
 
     fullPathTempDir = root + temp
+    fullPathSaveDir = root + save
+    if backupDir is not None:
+        fullPathSaveDir = backupDir
 
     ###########################################################################
     # If interactive, prompt for removal of temp directory                    #
@@ -600,66 +646,71 @@ def daily_uls_parse(state_root, interactive):
     ###########################################################################
 
     for region in regionList:
-
-        #######################################################################
-        # If interactive, prompt for downloading of data files for region         #
-        #######################################################################
-        if wfaFlag:
-            downloadDataFilesFlag = False
-        elif interactive:
-            accepted = False
-            while not accepted:
-                value = input("Download data files for " +
-                              region + "? (y/n): ")
-                if value == "y":
-                    accepted = True
-                    downloadDataFilesFlag = True
-                elif value == "n":
-                    accepted = True
-                    downloadDataFilesFlag = False
-                else:
-                    print("ERROR: Invalid input: " +
-                          value + ", must be y or n")
-        else:
-            downloadDataFilesFlag = True
-        #######################################################################
-
-        #######################################################################
-        # If downloadDataFilesFlag set, download data files for region            #
-        #######################################################################
-        if downloadDataFilesFlag:
-            downloadFiles(region, logFile, currentWeekday, fullPathTempDir)
-        #######################################################################
-
-        regionDataDir = fullPathTempDir + '/' + region
-
-        if region == 'US':
-            ###################################################################
-            # If interactive, prompt for extraction of files from zip files           #
-            ###################################################################
+        try:
+            #######################################################################
+            # If interactive, prompt for downloading of data files for region         #
+            #######################################################################
             if wfaFlag:
-                extractZipFlag = True
+                downloadDataFilesFlag = False
             elif interactive:
-                value = input(
-                    "Extract FCC files from downloaded zip files? (y/n): ")
-                if value == "y":
-                    extractZipFlag = True
-                elif value == "n":
-                    extractZipFlag = False
-                else:
-                    print("ERROR: Invalid input: " +
-                          value + ", must be y or n")
+                accepted = False
+                while not accepted:
+                    value = input("Download data files for " +
+                                region + "? (y/n): ")
+                    if value == "y":
+                        accepted = True
+                        downloadDataFilesFlag = True
+                    elif value == "n":
+                        accepted = True
+                        downloadDataFilesFlag = False
+                    else:
+                        print("ERROR: Invalid input: " +
+                            value + ", must be y or n")
             else:
-                extractZipFlag = True
-            ###################################################################
+                downloadDataFilesFlag = True
+            #######################################################################
 
-            ###################################################################
-            # If extractZipFlag set, extract files from zip files                     #
-            ###################################################################
-            if extractZipFlag:
-                extractZips(logFile, regionDataDir)
-            ###################################################################
+            #######################################################################
+            # If downloadDataFilesFlag set, download data files for region            #
+            #######################################################################
+            if downloadDataFilesFlag:
+                downloadFiles(region, logFile, currentWeekday, fullPathTempDir)
+            #######################################################################
 
+            regionDataDir = fullPathTempDir + '/' + region
+
+            if region == 'US':
+                ###################################################################
+                # If interactive, prompt for extraction of files from zip files           #
+                ###################################################################
+                if wfaFlag:
+                    extractZipFlag = True
+                elif interactive:
+                    value = input(
+                        "Extract FCC files from downloaded zip files? (y/n): ")
+                    if value == "y":
+                        extractZipFlag = True
+                    elif value == "n":
+                        extractZipFlag = False
+                    else:
+                        print("ERROR: Invalid input: " +
+                            value + ", must be y or n")
+                else:
+                    extractZipFlag = True
+                ###################################################################
+
+                ###################################################################
+                # If extractZipFlag set, extract files from zip files                     #
+                ###################################################################
+                if extractZipFlag:
+                    extractZips(logFile, regionDataDir)
+                ###################################################################
+        except:
+            if region == 'US':
+                didUSFail = handleRegionFailure(region, didUSFail, fullPathSaveDir, fullPathTempDir)
+            elif region == 'CA':
+                didCAFail = handleRegionFailure(region, didCAFail, fullPathSaveDir, fullPathTempDir)
+            
     ###########################################################################
     # If interactive, prompt for converting AFC GitHub data files            #
     ###########################################################################
@@ -740,10 +791,18 @@ def daily_uls_parse(state_root, interactive):
     # antenna_model_list.csv                                                  #
     ###########################################################################
     if processAntFilesFlag:
-        processAntFiles(fullPathTempDir, processCA, combineAntennaRegionFlag,
-                        fullPathTempDir + '/antenna_model_list.csv',
-                        fullPathTempDir + '/antenna_prefix_list.csv',
-                        fullPathAntennaPatternFile, logFile)
+        try:
+            processAntFiles(fullPathTempDir, processCA, combineAntennaRegionFlag,
+                                fullPathTempDir + '/antenna_model_list.csv',
+                                fullPathTempDir + '/antenna_prefix_list.csv',
+                                fullPathAntennaPatternFile, logFile)
+        except:
+            # Only CA is accessed so the assumption is CA Failed
+            didCAFail = handleRegionFailure('CA', didCAFail, fullPathSaveDir, fullPathTempDir)
+            processAntFiles(fullPathTempDir, processCA, combineAntennaRegionFlag,
+                                fullPathTempDir + '/antenna_model_list.csv',
+                                fullPathTempDir + '/antenna_prefix_list.csv',
+                                fullPathAntennaPatternFile, logFile)
     ###########################################################################
 
     ###########################################################################
@@ -786,31 +845,55 @@ def daily_uls_parse(state_root, interactive):
             dataIdentity = None
 
             if region == 'US':
-                # US files (FCC) consist of weekly and daily updates.
-                # get the time creation of weekly file from the counts file
-                weeklyCreation = verifyCountsFile(regionDataDir + '/weekly')
-                # process the daily files day by day
-                uploadTime = processDailyFiles(
-                    weeklyCreation, logFile, regionDataDir, currentWeekday)
-                # For US identity is FCC ULS upoload datetime
-                dataIdentity = uploadTime.isoformat()
+                try:
+                    # US files (FCC) consist of weekly and daily updates.
+                    # get the time creation of weekly file from the counts file
+                    weeklyCreation = verifyCountsFile(regionDataDir + '/weekly')
+                    # process the daily files day by day
+                    uploadTime = processDailyFiles(
+                        weeklyCreation, logFile, regionDataDir, currentWeekday)
+                    # For US identity is FCC ULS upoload datetime
+                    dataIdentity = uploadTime.isoformat()
 
-                rasDataFileUSSrc = root + '/data_files/RASdatabase.dat'
-                rasDataFileUSTgt = regionDataDir + '/weekly/RA.dat_withDaily'
-                logFile.write("Copying " + rasDataFileUSSrc +
-                              ' to ' + rasDataFileUSTgt + '\n')
-                subprocess.call(['cp', rasDataFileUSSrc, rasDataFileUSTgt])
+                    rasDataFileUSSrc = root + '/data_files/RASdatabase.dat'
+                    rasDataFileUSTgt = regionDataDir + '/weekly/RA.dat_withDaily'
+                    logFile.write("Copying " + rasDataFileUSSrc +
+                                ' to ' + rasDataFileUSTgt + '\n')
+                    subprocess.call(['cp', rasDataFileUSSrc, rasDataFileUSTgt])
 
-                # generate the combined csv/txt file for the coalition uls
-                # processor
-                generateUlsScriptInputUS(
-                    regionDataDir + '/weekly',
-                    logFile,
-                    fullPathCoalitionScriptInput)
+                    # generate the combined csv/txt file for the coalition uls
+                    # processor
+                    generateUlsScriptInputUS(
+                        regionDataDir + '/weekly',
+                        logFile,
+                        fullPathCoalitionScriptInput)
+                except: 
+                    didUSFail = handleRegionFailure(region, didUSFail, fullPathSaveDir, fullPathTempDir)
+                    
+                    weeklyCreation = verifyCountsFile(regionDataDir + '/weekly')
+                    uploadTime = processDailyFiles(
+                        weeklyCreation, logFile, regionDataDir, currentWeekday)
+                    dataIdentity = uploadTime.isoformat()
+
+                    rasDataFileUSSrc = root + '/data_files/RASdatabase.dat'
+                    rasDataFileUSTgt = regionDataDir + '/weekly/RA.dat_withDaily'
+                    logFile.write("Copying " + rasDataFileUSSrc +
+                                ' to ' + rasDataFileUSTgt + '\n')
+                    subprocess.call(['cp', rasDataFileUSSrc, rasDataFileUSTgt])
+                    generateUlsScriptInputUS(
+                        regionDataDir + '/weekly',
+                        logFile,
+                        fullPathCoalitionScriptInput)
+
             elif region == 'CA':
                 # For Canada identity is MD5 of downloaded files
-                dataIdentity = generateUlsScriptInputCA(
-                    regionDataDir, logFile, fullPathCoalitionScriptInput)
+                try:
+                    dataIdentity = generateUlsScriptInputCA(
+                        regionDataDir, logFile, fullPathCoalitionScriptInput)
+                except:
+                    didCAFail = handleRegionFailure(region, didCAFail, fullPathSaveDir, fullPathTempDir)
+                    dataIdentity = generateUlsScriptInputCA(
+                        regionDataDir, logFile, fullPathCoalitionScriptInput)
             else:
                 logFile.write('ERROR: Invalid region = ' + region)
                 raise e
@@ -1127,6 +1210,8 @@ if __name__ == '__main__':
 
     parser.add_argument('-r', '--region', default='US:CA',
                         help='":" separated list of regions')
+    parser.add_argument('-s_dir', '--saved_dir', default=None,
+                        help='Location of the saves')
 
     args = parser.parse_args()
     interactive = args.interactive
@@ -1167,6 +1252,11 @@ if __name__ == '__main__':
     print("WFA = " + str(wfaFlag))
 
     regionList = args.region.split(':')
+    
+    backupDir = None
+    if args.saved_dir is not None:
+        backupDir = str(args.saved_dir)
+        print("Backups are expected to be located at " + str(backupDir))
 
     processUS = False
     processCA = False

--- a/src/ratapi/ratapi/db/daily_uls_parse.py
+++ b/src/ratapi/ratapi/db/daily_uls_parse.py
@@ -145,6 +145,8 @@ def downloadFiles(region, logFile, currentWeekday, fullPathTempDir):
 # Downloads antenna files
 
 # Retrieves the most recent download from the passed region
+
+
 def getMostRecentRegionDownload(region, fullPathSaveDir):
     regionSaveParentDir = os.path.join(fullPathSaveDir, region)
 
@@ -155,7 +157,7 @@ def getMostRecentRegionDownload(region, fullPathSaveDir):
 
     if existingBackups:
         existingBackups.sort()
-        
+
         mostRecentName = existingBackups[-1]
         mostRecentPath = os.path.join(regionSaveParentDir, mostRecentName)
         return mostRecentPath
@@ -163,6 +165,8 @@ def getMostRecentRegionDownload(region, fullPathSaveDir):
         return None
     
 # Replaces the region data with the most recent backup found in the saved directory
+
+
 def replaceRegionDataWithLastSuccess(region, fullPathSaveDir, fullPathTempDir):
     destDir = os.path.join(fullPathTempDir, region)
 
@@ -174,14 +178,17 @@ def replaceRegionDataWithLastSuccess(region, fullPathSaveDir, fullPathTempDir):
     shutil.copytree(srcDir, destDir)
 
 # Handles a failure of a region, returning or crashing based on the passed flag
+
+
 def handleRegionFailure(region, regionFailureFlag, fullPathSaveDir, fullPathTempDir):
     if not regionFailureFlag:
         print(f"Attempting to replace the failed download of region: {region} with last success.")
         replaceRegionDataWithLastSuccess(region, fullPathSaveDir, fullPathTempDir)
         print(f"Replacement Successful.")
-        return True # Original Download has failed
+        return True  # Original Download has failed
     else:
         raise RuntimeError(f"Previously successful data has failed.")
+
 
 def prepareAFCGitHubFiles(rawDir, destDir, logFile):
     # Files in rawDir are downloaded from
@@ -648,15 +655,14 @@ def daily_uls_parse(state_root, interactive):
     for region in regionList:
         try:
             #######################################################################
-            # If interactive, prompt for downloading of data files for region         #
+            # If interactive, prompt for downloading of data files for region     #
             #######################################################################
             if wfaFlag:
                 downloadDataFilesFlag = False
             elif interactive:
                 accepted = False
                 while not accepted:
-                    value = input("Download data files for " +
-                                region + "? (y/n): ")
+                    value = input("Download data files for " + region + "? (y/n): ")
                     if value == "y":
                         accepted = True
                         downloadDataFilesFlag = True
@@ -664,14 +670,13 @@ def daily_uls_parse(state_root, interactive):
                         accepted = True
                         downloadDataFilesFlag = False
                     else:
-                        print("ERROR: Invalid input: " +
-                            value + ", must be y or n")
+                        print("ERROR: Invalid input: " + value + ", must be y or n")
             else:
                 downloadDataFilesFlag = True
             #######################################################################
 
             #######################################################################
-            # If downloadDataFilesFlag set, download data files for region            #
+            # If downloadDataFilesFlag set, download data files for region        #
             #######################################################################
             if downloadDataFilesFlag:
                 downloadFiles(region, logFile, currentWeekday, fullPathTempDir)
@@ -681,7 +686,7 @@ def daily_uls_parse(state_root, interactive):
 
             if region == 'US':
                 ###################################################################
-                # If interactive, prompt for extraction of files from zip files           #
+                # If interactive, prompt for extraction of files from zip files   #
                 ###################################################################
                 if wfaFlag:
                     extractZipFlag = True
@@ -693,8 +698,7 @@ def daily_uls_parse(state_root, interactive):
                     elif value == "n":
                         extractZipFlag = False
                     else:
-                        print("ERROR: Invalid input: " +
-                            value + ", must be y or n")
+                        print("ERROR: Invalid input: " + value + ", must be y or n")
                 else:
                     extractZipFlag = True
                 ###################################################################
@@ -705,7 +709,7 @@ def daily_uls_parse(state_root, interactive):
                 if extractZipFlag:
                     extractZips(logFile, regionDataDir)
                 ###################################################################
-        except:
+        except Exception as e:
             if region == 'US':
                 didUSFail = handleRegionFailure(region, didUSFail, fullPathSaveDir, fullPathTempDir)
             elif region == 'CA':
@@ -793,16 +797,16 @@ def daily_uls_parse(state_root, interactive):
     if processAntFilesFlag:
         try:
             processAntFiles(fullPathTempDir, processCA, combineAntennaRegionFlag,
-                                fullPathTempDir + '/antenna_model_list.csv',
-                                fullPathTempDir + '/antenna_prefix_list.csv',
-                                fullPathAntennaPatternFile, logFile)
-        except:
+                            fullPathTempDir + '/antenna_model_list.csv',
+                            fullPathTempDir + '/antenna_prefix_list.csv',
+                            fullPathAntennaPatternFile, logFile)
+        except Exception as e:
             # Only CA is accessed so the assumption is CA Failed
             didCAFail = handleRegionFailure('CA', didCAFail, fullPathSaveDir, fullPathTempDir)
             processAntFiles(fullPathTempDir, processCA, combineAntennaRegionFlag,
-                                fullPathTempDir + '/antenna_model_list.csv',
-                                fullPathTempDir + '/antenna_prefix_list.csv',
-                                fullPathAntennaPatternFile, logFile)
+                            fullPathTempDir + '/antenna_model_list.csv',
+                            fullPathTempDir + '/antenna_prefix_list.csv',
+                            fullPathAntennaPatternFile, logFile)
     ###########################################################################
 
     ###########################################################################
@@ -858,7 +862,7 @@ def daily_uls_parse(state_root, interactive):
                     rasDataFileUSSrc = root + '/data_files/RASdatabase.dat'
                     rasDataFileUSTgt = regionDataDir + '/weekly/RA.dat_withDaily'
                     logFile.write("Copying " + rasDataFileUSSrc +
-                                ' to ' + rasDataFileUSTgt + '\n')
+                                  ' to ' + rasDataFileUSTgt + '\n')
                     subprocess.call(['cp', rasDataFileUSSrc, rasDataFileUSTgt])
 
                     # generate the combined csv/txt file for the coalition uls
@@ -867,9 +871,9 @@ def daily_uls_parse(state_root, interactive):
                         regionDataDir + '/weekly',
                         logFile,
                         fullPathCoalitionScriptInput)
-                except: 
+                except Exception as e: 
                     didUSFail = handleRegionFailure(region, didUSFail, fullPathSaveDir, fullPathTempDir)
-                    
+
                     weeklyCreation = verifyCountsFile(regionDataDir + '/weekly')
                     uploadTime = processDailyFiles(
                         weeklyCreation, logFile, regionDataDir, currentWeekday)
@@ -878,7 +882,7 @@ def daily_uls_parse(state_root, interactive):
                     rasDataFileUSSrc = root + '/data_files/RASdatabase.dat'
                     rasDataFileUSTgt = regionDataDir + '/weekly/RA.dat_withDaily'
                     logFile.write("Copying " + rasDataFileUSSrc +
-                                ' to ' + rasDataFileUSTgt + '\n')
+                                  ' to ' + rasDataFileUSTgt + '\n')
                     subprocess.call(['cp', rasDataFileUSSrc, rasDataFileUSTgt])
                     generateUlsScriptInputUS(
                         regionDataDir + '/weekly',
@@ -890,7 +894,7 @@ def daily_uls_parse(state_root, interactive):
                 try:
                     dataIdentity = generateUlsScriptInputCA(
                         regionDataDir, logFile, fullPathCoalitionScriptInput)
-                except:
+                except Exception as e:
                     didCAFail = handleRegionFailure(region, didCAFail, fullPathSaveDir, fullPathTempDir)
                     dataIdentity = generateUlsScriptInputCA(
                         regionDataDir, logFile, fullPathCoalitionScriptInput)
@@ -1210,7 +1214,7 @@ if __name__ == '__main__':
 
     parser.add_argument('-r', '--region', default='US:CA',
                         help='":" separated list of regions')
-    parser.add_argument('-s_dir', '--saved_dir', default=None,
+    parser.add_argument('-s_dir', '--save_dir', default=None,
                         help='Location of the saves')
 
     args = parser.parse_args()
@@ -1252,10 +1256,10 @@ if __name__ == '__main__':
     print("WFA = " + str(wfaFlag))
 
     regionList = args.region.split(':')
-    
+
     backupDir = None
-    if args.saved_dir is not None:
-        backupDir = str(args.saved_dir)
+    if args.save_dir is not None:
+        backupDir = str(args.save_dir)
         print("Backups are expected to be located at " + str(backupDir))
 
     processUS = False

--- a/src/ratapi/ratapi/db/daily_uls_parse.py
+++ b/src/ratapi/ratapi/db/daily_uls_parse.py
@@ -151,7 +151,7 @@ def getMostRecentRegionDownload(region, fullPathSaveDir):
     regionSaveParentDir = os.path.join(fullPathSaveDir, region)
 
     existingBackups = [
-        d for d in os.listdir(regionSaveParentDir) 
+        d for d in os.listdir(regionSaveParentDir)
         if os.path.isdir(os.path.join(regionSaveParentDir, d))
     ]
 
@@ -163,7 +163,7 @@ def getMostRecentRegionDownload(region, fullPathSaveDir):
         return mostRecentPath
     else:
         return None
-    
+
 # Replaces the region data with the most recent backup found in the saved directory
 
 
@@ -714,7 +714,7 @@ def daily_uls_parse(state_root, interactive):
                 didUSFail = handleRegionFailure(region, didUSFail, fullPathSaveDir, fullPathTempDir)
             elif region == 'CA':
                 didCAFail = handleRegionFailure(region, didCAFail, fullPathSaveDir, fullPathTempDir)
-            
+
     ###########################################################################
     # If interactive, prompt for converting AFC GitHub data files            #
     ###########################################################################
@@ -871,7 +871,7 @@ def daily_uls_parse(state_root, interactive):
                         regionDataDir + '/weekly',
                         logFile,
                         fullPathCoalitionScriptInput)
-                except Exception as e: 
+                except Exception as e:
                     didUSFail = handleRegionFailure(region, didUSFail, fullPathSaveDir, fullPathTempDir)
 
                     weeklyCreation = verifyCountsFile(regionDataDir + '/weekly')

--- a/uls/uls_service.py
+++ b/uls/uls_service.py
@@ -98,6 +98,13 @@ class Settings(pydantic.BaseSettings):
             "/mnt/nfs/rat_transfer/daily_uls_parse/temp/", env="ULS_TEMP_DIR",
             description="Temporary directory of ULS download script, cleaned "
             "before downloading")
+    save_dir: str = \
+        pydantic.Field(
+            "/rat_transfer/daily_uls_parse/country_history/", env="ULS_SAVE_DIR",
+            description="Directory where download script puts downloaded file for country")
+    num_saves: Optional[int] = \
+        pydantic.Field(3, env="NUM_SAVE",
+                       description="Number of backup saved for data")
     ext_db_dir: str = \
         pydantic.Field(
             ..., env="ULS_EXT_DB_DIR",
@@ -608,6 +615,41 @@ def update_uls_file(uls_dir: str, uls_file: str, symlink: str,
         fail_on_error=True)
     logging.info(f"FS database symlink '{os.path.join(uls_dir, symlink)}' "
                  f"now points to '{uls_file}'")
+    
+def save_recent_download(regions, num_of_saves, recent_download_dir: str, saved_download_dir: str) -> None:
+    """ Handles the saving and storage of the country downloads
+
+    Arguments:
+    regions  -- List of regions to saves 
+    uls_file -- Base name of new ULS file (already in ULS directory)
+    symlink  -- Base name of symlink pointing to current ULS file
+    executor -- LoggingExecutor object
+    """
+    startTime = datetime.datetime.now()
+    nameTime = startTime.isoformat(timespec='seconds').replace(":", '_')
+    newSaveName = f"{nameTime}"
+    
+    for region in regions:
+        regionDataDir = os.path.join(recent_download_dir, region)
+        regionSaveParentDir = os.path.join(saved_download_dir, region)
+        saveDir = os.path.join(regionSaveParentDir, newSaveName)
+        shutil.copytree(regionDataDir, saveDir)
+
+        existingBackups = [
+            d for d in os.listdir(regionSaveParentDir) 
+            if os.path.isdir(os.path.join(regionSaveParentDir, d))
+        ]
+        
+        existingBackups.sort()
+        
+        while len(existingBackups) > num_of_saves:
+            oldestBackupName = existingBackups.pop(0) 
+            oldest_backup_path = os.path.join(regionSaveParentDir, oldestBackupName)
+            
+            shutil.rmtree(oldest_backup_path)
+
+    logging.info(f"Successfully saved the recent downloads to backups for: "
+                                 f"{', '.join(sorted(regions))}")
 
 
 class DbDiff:
@@ -999,6 +1041,14 @@ def main(argv: List[str]) -> None:
         help=f"Directory containing downloader's temporary files (cleared "
         f"before downloading){env_help(Settings, 'temp_dir')}")
     argument_parser.add_argument(
+        "--save_dir", metavar="SAVE_DIR",
+        help=f"Directory containing downloader's saved files "
+        f"per region){env_help(Settings, 'save_dir')}")
+    argument_parser.add_argument(
+        "--num_save", metavar="NUM_SAVE",
+        help=f"Number of saved prior downloads "
+        f"expected ){env_help(Settings, 'num_saves')}")
+    argument_parser.add_argument(
         "--ext_db_dir", metavar="EXTERNAL_DATABASE_DIR",
         help=f"Directory where new ULS databases should be copied. If "
         f"--ext_db_symlink contains path, this parameter is root directory "
@@ -1235,6 +1285,7 @@ def main(argv: List[str]) -> None:
                 cmdline_args.append(settings.download_script)
                 if settings.region:
                     cmdline_args += ["--region", settings.region]
+                cmdline_args += ["--saved_dir", settings.save_dir]
                 if settings.download_script_args:
                     cmdline_args.append(settings.download_script_args)
                 logging.info(f"Starting {' '.join(cmdline_args)}")
@@ -1357,6 +1408,14 @@ def main(argv: List[str]) -> None:
                                      db_diff.diff_tiles[: 1000]]
                                 rcache.rcache_spatial_invalidate(
                                     tiles=db_diff.diff_tiles)
+                        
+                        # Upon success, save the new region files
+                        if settings.force:
+                            # Saves regardless of new data
+                            save_recent_download(set(new_uls_identity.keys()), settings.num_saves, settings.temp_dir, settings.save_dir)
+                        else:
+                            # Saves based on new data
+                            save_recent_download(updated_regions, settings.num_saves, settings.temp_dir, settings.save_dir)
 
                         # Update data change times (for health checker)
                         status_updater.milestone(

--- a/uls/uls_service.py
+++ b/uls/uls_service.py
@@ -616,19 +616,20 @@ def update_uls_file(uls_dir: str, uls_file: str, symlink: str,
     logging.info(f"FS database symlink '{os.path.join(uls_dir, symlink)}' "
                  f"now points to '{uls_file}'")
     
+
 def save_recent_download(regions, num_of_saves, recent_download_dir: str, saved_download_dir: str) -> None:
     """ Handles the saving and storage of the country downloads
 
     Arguments:
-    regions  -- List of regions to saves 
-    uls_file -- Base name of new ULS file (already in ULS directory)
-    symlink  -- Base name of symlink pointing to current ULS file
-    executor -- LoggingExecutor object
+    regions  -- List of regions to saves
+    num_of_saves -- Number of backups to save
+    recent_download_dir  -- Location of where the most recent download took place
+    saved_download_dir -- Location of where to save the backups
     """
     startTime = datetime.datetime.now()
     nameTime = startTime.isoformat(timespec='seconds').replace(":", '_')
     newSaveName = f"{nameTime}"
-    
+
     for region in regions:
         regionDataDir = os.path.join(recent_download_dir, region)
         regionSaveParentDir = os.path.join(saved_download_dir, region)
@@ -636,20 +637,20 @@ def save_recent_download(regions, num_of_saves, recent_download_dir: str, saved_
         shutil.copytree(regionDataDir, saveDir)
 
         existingBackups = [
-            d for d in os.listdir(regionSaveParentDir) 
+            d for d in os.listdir(regionSaveParentDir)
             if os.path.isdir(os.path.join(regionSaveParentDir, d))
         ]
-        
+
         existingBackups.sort()
-        
+
         while len(existingBackups) > num_of_saves:
-            oldestBackupName = existingBackups.pop(0) 
+            oldestBackupName = existingBackups.pop(0)
             oldest_backup_path = os.path.join(regionSaveParentDir, oldestBackupName)
-            
+
             shutil.rmtree(oldest_backup_path)
 
     logging.info(f"Successfully saved the recent downloads to backups for: "
-                                 f"{', '.join(sorted(regions))}")
+                 f"{', '.join(sorted(regions))}")
 
 
 class DbDiff:
@@ -1042,11 +1043,11 @@ def main(argv: List[str]) -> None:
         f"before downloading){env_help(Settings, 'temp_dir')}")
     argument_parser.add_argument(
         "--save_dir", metavar="SAVE_DIR",
-        help=f"Directory containing downloader's saved files "
+        help=f"Directory containing uls downloader's previously successful downloaded region files"
         f"per region){env_help(Settings, 'save_dir')}")
     argument_parser.add_argument(
         "--num_save", metavar="NUM_SAVE",
-        help=f"Number of saved prior downloads "
+        help=f"Number of successful region files prior downloads expected"
         f"expected ){env_help(Settings, 'num_saves')}")
     argument_parser.add_argument(
         "--ext_db_dir", metavar="EXTERNAL_DATABASE_DIR",
@@ -1408,7 +1409,7 @@ def main(argv: List[str]) -> None:
                                      db_diff.diff_tiles[: 1000]]
                                 rcache.rcache_spatial_invalidate(
                                     tiles=db_diff.diff_tiles)
-                        
+
                         # Upon success, save the new region files
                         if settings.force:
                             # Saves regardless of new data

--- a/uls/uls_service.py
+++ b/uls/uls_service.py
@@ -1047,7 +1047,7 @@ def main(argv: List[str]) -> None:
         f"per region){env_help(Settings, 'save_dir')}")
     argument_parser.add_argument(
         "--num_save", metavar="NUM_SAVE",
-        help=f"Number of successful region files prior downloads expected"
+        help=f"Number of previously successful region files to save"
         f"expected ){env_help(Settings, 'num_saves')}")
     argument_parser.add_argument(
         "--ext_db_dir", metavar="EXTERNAL_DATABASE_DIR",

--- a/uls/uls_service.py
+++ b/uls/uls_service.py
@@ -615,7 +615,7 @@ def update_uls_file(uls_dir: str, uls_file: str, symlink: str,
         fail_on_error=True)
     logging.info(f"FS database symlink '{os.path.join(uls_dir, symlink)}' "
                  f"now points to '{uls_file}'")
-    
+
 
 def save_recent_download(regions, num_of_saves, recent_download_dir: str, saved_download_dir: str) -> None:
     """ Handles the saving and storage of the country downloads
@@ -1286,7 +1286,7 @@ def main(argv: List[str]) -> None:
                 cmdline_args.append(settings.download_script)
                 if settings.region:
                     cmdline_args += ["--region", settings.region]
-                cmdline_args += ["--saved_dir", settings.save_dir]
+                cmdline_args += ["--save_dir", settings.save_dir]
                 if settings.download_script_args:
                     cmdline_args.append(settings.download_script_args)
                 logging.info(f"Starting {' '.join(cmdline_args)}")


### PR DESCRIPTION
Updated ULS Downloader to process countries independently to avoid failure due to one country. The strategy is to catch initial failure and replace the downloaded data with a previously successful run. 

The issue can be found at: https://github.com/open-afc-project/openafc/issues/430